### PR TITLE
(fix) #13 Prevent preferredRules from being collected after caret position

### DIFF
--- a/src/CodeCompletionCore.ts
+++ b/src/CodeCompletionCore.ts
@@ -467,9 +467,6 @@ export class CodeCompletionCore {
 
                     default: {
                         if (transition.isEpsilon) {
-                            if (atCaret) {
-                                this.translateToRuleIndex(callStack);
-                            }
                             // Jump over simple states with a single outgoing epsilon transition.
                             statePipeline.push({ state: transition.target, tokenIndex: currentEntry.tokenIndex });
                             continue;

--- a/test/test.ts
+++ b/test/test.ts
@@ -467,7 +467,7 @@ describe('antlr4-c3:', function () {
             // 6) On the whitespace just after the variable reference 'a' (but it could still be a function reference!)
             candidates = core.collectCandidates(7);
             expect(candidates.tokens.size, "Test 11").to.equal(0);
-            expect(candidates.rules.size, "Test 12").to.equal(2);
+            expect(candidates.rules.size, "Test 12").to.equal(1);
         });
     });
 


### PR DESCRIPTION
Fixes https://github.com/mike-lischke/antlr4-c3/issues/13

It seems that the unit test change here is also correct, as we expect it to still match functionRef, but no longer match variableRef.

The unit tests in my test grammar as well as a production grammar I'm working with all pass with correct expectations after this update.