### PR TITLE
fix: issue collectFollowSets works incorrectly when...

### DIFF
--- a/src/CodeCompletionCore.ts
+++ b/src/CodeCompletionCore.ts
@@ -231,7 +231,7 @@ export class CodeCompletionCore {
      */
     private determineFollowSets(start: ATNState, stop: ATNState): FollowSetWithPath[] {
         let result: FollowSetWithPath[] = [];
-        let seen: Set<ATNState> = new Set();
+        let seen: Set<PipelineEntry> = new Set();
         let ruleStack: number[] = [];
         this.collectFollowSets(start, stop, result, seen, ruleStack);
 
@@ -242,12 +242,19 @@ export class CodeCompletionCore {
      * Collects possible tokens which could be matched following the given ATN state. This is essentially the same
      * algorithm as used in the LL1Analyzer class, but here we consider predicates also and use no parser rule context.
      */
-    private collectFollowSets(s: ATNState, stopState: ATNState, followSets: FollowSetWithPath[], seen: Set<ATNState>, ruleStack: number[]) {
+    private collectFollowSets(s: ATNState, stopState: ATNState, followSets: FollowSetWithPath[], seen: Set<PipelineEntry>, ruleStack: number[]) {
 
-        if (seen.has(s))
+        const entry = new PipelineEntry();
+        entry.state = s;
+        entry.tokenIndex = Infinity;
+        if (ruleStack.length > 0) {
+            entry.tokenIndex = ruleStack[ruleStack.length - 1];
+        }
+
+        if (seen.has(entry))
             return;
 
-        seen.add(s);
+        seen.add(entry);
 
         if (s == stopState || s.stateType == ATNStateType.RULE_STOP) {
             let set = new FollowSetWithPath();

--- a/test/test.ts
+++ b/test/test.ts
@@ -568,26 +568,20 @@ describe('antlr4-c3:', function () {
                 CPP14Parser.RULE_translationunit,
                 CPP14Parser.RULE_declarationseq,
                 CPP14Parser.RULE_declaration,
-                CPP14Parser.RULE_blockdeclaration,
-                CPP14Parser.RULE_simpledeclaration,
-                CPP14Parser.RULE_declspecifierseq,
-                CPP14Parser.RULE_declspecifier,
-                CPP14Parser.RULE_typespecifier,
-                CPP14Parser.RULE_trailingtypespecifier,
-                CPP14Parser.RULE_simpletypespecifier,
+                CPP14Parser.RULE_functiondefinition,
+                CPP14Parser.RULE_declarator,
+                CPP14Parser.RULE_ptrdeclarator,
+                CPP14Parser.RULE_ptroperator,
                 CPP14Parser.RULE_nestednamespecifier,
             ]);
             expect(candidates.rules.get(CPP14Parser.RULE_classname), "Test 46").to.eql([
                 CPP14Parser.RULE_translationunit,
                 CPP14Parser.RULE_declarationseq,
                 CPP14Parser.RULE_declaration,
-                CPP14Parser.RULE_blockdeclaration,
-                CPP14Parser.RULE_simpledeclaration,
-                CPP14Parser.RULE_declspecifierseq,
-                CPP14Parser.RULE_declspecifier,
-                CPP14Parser.RULE_typespecifier,
-                CPP14Parser.RULE_trailingtypespecifier,
-                CPP14Parser.RULE_simpletypespecifier,
+                CPP14Parser.RULE_functiondefinition,
+                CPP14Parser.RULE_declarator,
+                CPP14Parser.RULE_ptrdeclarator,
+                CPP14Parser.RULE_ptroperator,
                 CPP14Parser.RULE_nestednamespecifier,
                 CPP14Parser.RULE_typename,
             ]);
@@ -596,7 +590,7 @@ describe('antlr4-c3:', function () {
             //    Note when counting token indexes: the C++14 grammar skips all whitespaces, hence there are no tokens for them.
             candidates = core.collectCandidates(10);
 
-            expect(candidates.rules.size, "Test 47").to.equal(1);
+            expect(candidates.rules.size, "Test 47").to.equal(3);
             expect(candidates.rules.get(CPP14Parser.RULE_idexpression), "Test 48").to.eql([
                 CPP14Parser.RULE_translationunit,
                 CPP14Parser.RULE_declarationseq,
@@ -618,7 +612,6 @@ describe('antlr4-c3:', function () {
                 CPP14Parser.RULE_initializerclause,
 
                 CPP14Parser.RULE_assignmentexpression,
-                CPP14Parser.RULE_conditionalexpression,
                 CPP14Parser.RULE_logicalorexpression,
                 CPP14Parser.RULE_logicalandexpression,
                 CPP14Parser.RULE_inclusiveorexpression,
@@ -638,7 +631,7 @@ describe('antlr4-c3:', function () {
 
             // We are starting a primary expression in a function body, so everything related to expressions and control flow is allowed here.
             // We only check for a few possible keywords.
-            expect(candidates.tokens.size, "Test 49").to.equal(81);
+            expect(candidates.tokens.size, "Test 49").to.equal(82);
             expect(candidates.tokens.has(CPP14Lexer.If), "Test 50").to.equal(true);
             expect(candidates.tokens.has(CPP14Lexer.This), "Test 51").to.equal(true);
             expect(candidates.tokens.has(CPP14Lexer.New), "Test 52").to.equal(true);
@@ -693,7 +686,7 @@ describe('antlr4-c3:', function () {
 
             candidates = core.collectCandidates(12); // At the closing parenthesis -> again everything in an expression allowed (no control flow this time, tho).
 
-            expect(candidates.tokens.size, "Test 4").to.equal(64);
+            expect(candidates.tokens.size, "Test 4").to.equal(65);
             expect(candidates.tokens.has(CPP14Lexer.If), "Test 5").to.equal(false);
             expect(candidates.tokens.has(CPP14Lexer.This), "Test 6").to.equal(true);
             expect(candidates.tokens.has(CPP14Lexer.New), "Test 7").to.equal(true);
@@ -747,11 +740,11 @@ describe('antlr4-c3:', function () {
 
             let candidates = core.collectCandidates(3469);
 
-            expect(candidates.rules.size, "Test 47").to.equal(1);
+            expect(candidates.rules.size, "Test 47").to.equal(3);
 
             // We are starting a primary expression in a function body, so everything related to expressions and control flow is allowed here.
             // We only check for a few possible keywords.
-            expect(candidates.tokens.size, "Test 49").to.equal(81);
+            expect(candidates.tokens.size, "Test 49").to.equal(82);
             expect(candidates.tokens.has(CPP14Lexer.If), "Test 50").to.equal(true);
             expect(candidates.tokens.has(CPP14Lexer.This), "Test 51").to.equal(true);
             expect(candidates.tokens.has(CPP14Lexer.New), "Test 52").to.equal(true);


### PR DESCRIPTION
collectFollowSets cut recursion when it finds the same state but that's
a mistake

...
operand:
           varReference
         | Number
         | functionExpr;

varRefernce: name;
funcReference: funcName LPar  arguments  RPar;
funcName: name;

name:  Id;
...

funcName is cut because the state name.start has already discover
wich is a mistake.