### PR TITLE
Unable to use Antlr4-c3 with angular #34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "antlr4-c3",
-  "version": "1.1.11",
+  "version": "1.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/CodeCompletionCore.ts
+++ b/src/CodeCompletionCore.ts
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is released under the MIT license.
  * Copyright (c) 2016, 2017, Mike Lischke
  *
@@ -9,7 +9,7 @@
 
 import { Parser, Vocabulary, Token, TokenStream, RuleContext, ParserRuleContext } from 'antlr4ts';
 import { ATN, ATNState, ATNStateType, Transition, TransitionType, PredicateTransition, RuleTransition, RuleStartState, PrecedencePredicateTransition } from 'antlr4ts/atn';
-import { IntervalSet } from 'antlr4ts/misc';
+import { IntervalSet } from 'antlr4ts/misc/IntervalSet';
 
 export type TokenList = number[];
 export type RuleList = number[];


### PR DESCRIPTION
replaced `import { IntervalSet } from 'antlr4ts/misc';` with `import { IntervalSet } from 'antlr4ts/misc/IntervalSet';`