### PR TITLE
CodeCompletionCore.followSetsByATN non-static

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepublishOnly": "npm run test",
     "test": "tsc --version && npm run generate && tsc && mocha out/test",
-    "generate": "antlr4ts test/CPP14.g4 test/Expr.g4 -no-listener -no-visitor -o test",
+    "generate": "antlr4ts test/CPP14.g4 test/Expr.g4 test/PredicatedFooBar.g4 -no-listener -no-visitor -o test",
     "eslint": "eslint ."
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepublishOnly": "npm run test",
     "test": "tsc --version && npm run generate && tsc && mocha out/test",
-    "generate": "antlr4ts test/CPP14.g4 test/Expr.g4 -no-listener -no-visitor",
+    "generate": "antlr4ts test/CPP14.g4 test/Expr.g4 -no-listener -no-visitor -o test",
     "eslint": "eslint ."
   },
   "repository": {

--- a/src/CodeCompletionCore.ts
+++ b/src/CodeCompletionCore.ts
@@ -70,7 +70,7 @@ interface IPipelineEntry {
 
 // The main class for doing the collection process.
 export class CodeCompletionCore {
-    private static followSetsByATN = new Map<string, FollowSetsPerState>();
+    protected followSetsByATN = new Map<string, FollowSetsPerState>();
 
     private static atnStateTypeMap: string[] = [
         "invalid",
@@ -461,10 +461,10 @@ export class CodeCompletionCore {
         // 3) We get this lookup for free with any 2nd or further visit of the same rule, which often happens
         //    in non trivial grammars, especially with (recursive) expressions and of course when invoking code
         //    completion multiple times.
-        let setsPerState = CodeCompletionCore.followSetsByATN.get(this.parser.constructor.name);
+        let setsPerState = this.followSetsByATN.get(this.parser.constructor.name);
         if (!setsPerState) {
             setsPerState = new Map();
-            CodeCompletionCore.followSetsByATN.set(this.parser.constructor.name, setsPerState);
+            this.followSetsByATN.set(this.parser.constructor.name, setsPerState);
         }
 
         let followSets = setsPerState.get(startState.stateNumber);

--- a/test/PredicatedFooBar.g4
+++ b/test/PredicatedFooBar.g4
@@ -1,7 +1,10 @@
 grammar PredicatedFooBar;
-@members {
+
+@parser::members {
     public hasBar = false;
 }
+
+
 nonEmptyExpression: expression
                   | EOF /* workaround for empty input */
                   ;

--- a/test/PredicatedFooBar.g4
+++ b/test/PredicatedFooBar.g4
@@ -1,0 +1,20 @@
+grammar PredicatedFooBar;
+@members {
+    public hasBar = false;
+}
+nonEmptyExpression: expression
+                  | EOF /* workaround for empty input */
+                  ;
+
+expression:                foo
+          | {this.hasBar}? bar
+          ;
+
+foo: FOO ;
+bar: BAR ;
+
+FOO: [fF] [oO] [oO];
+BAR: [bB] [aA] [rR];
+
+ID: [a-zA-Z] [a-zA-Z0-9_]*;
+WS: [ \n\r\t] -> channel(HIDDEN);

--- a/test/test.ts
+++ b/test/test.ts
@@ -15,6 +15,8 @@ import { ExprParser } from "./ExprParser";
 import { ExprLexer } from "./ExprLexer";
 import { CPP14Parser } from "./CPP14Parser";
 import { CPP14Lexer } from "./CPP14Lexer";
+import { PredicatedFooBarLexer } from "./PredicatedFooBarLexer";
+import { PredicatedFooBarParser } from "./PredicatedFooBarParser";
 
 import * as c3 from "../index";
 
@@ -952,5 +954,52 @@ describe("antlr4-c3:", function () {
         }).timeout(60000);
     });
 
+    
+    describe("Predicated foo bar:", () => {
+        const inputStream = CharStreams.fromString("bar");
+
+        it("PredicatedFooBar, bar-rule disabled", () => {
+            const lexer = new PredicatedFooBarLexer(inputStream);
+            const tokenStream = new CommonTokenStream(lexer);
+
+            const parser = new PredicatedFooBarParser(tokenStream);
+            parser.expression();
+
+            const core = new c3.CodeCompletionCore(parser);
+
+            // 1) At the input start.
+            let candidates = core.collectCandidates(0);
+            // delete workaround token
+            candidates.tokens.delete(PredicatedFooBarParser.EOF);
+
+            expect(candidates.tokens.size, "Test 1").to.equal(1);
+            expect(candidates.tokens.has(PredicatedFooBarParser.FOO), "Test 2").to.equal(true);
+            expect(candidates.tokens.has(PredicatedFooBarParser.BAR), "Test 2").to.equal(false);
+        });
+
+        it("PredicatedFooBar, bar-rule enabled", () => {
+            const lexer = new PredicatedFooBarLexer(inputStream);
+            lexer.hasBar = true;   // enable the `bar`-rule
+
+            const tokenStream = new CommonTokenStream(lexer);
+
+            const parser = new PredicatedFooBarParser(tokenStream);
+            
+            parser.hasBar = true;   // enable the `bar`-rule
+            parser.nonEmptyExpression();
+
+            const core = new c3.CodeCompletionCore(parser);
+
+            // 1) At the input start.
+            let candidates = core.collectCandidates(0);
+            // delete workaround token
+            candidates.tokens.delete(PredicatedFooBarParser.EOF);
+
+            expect(candidates.tokens.size, "Test 1a").to.equal(2);
+            expect(candidates.tokens.has(PredicatedFooBarParser.FOO), "Test 2a").to.equal(true);
+            expect(candidates.tokens.has(PredicatedFooBarParser.BAR), "Test 2a").to.equal(true);
+        });
+
+    });
 
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -956,48 +956,93 @@ describe("antlr4-c3:", function () {
 
     
     describe("Predicated foo bar:", () => {
-        const inputStream = CharStreams.fromString("bar");
+        const inputStream = CharStreams.fromString("");
 
-        it("PredicatedFooBar, bar-rule disabled", () => {
-            const lexer = new PredicatedFooBarLexer(inputStream);
-            const tokenStream = new CommonTokenStream(lexer);
+        it("`bar` disabled, then enabled", () => {
+            {
+                const lexer = new PredicatedFooBarLexer(inputStream);
+                const tokenStream = new CommonTokenStream(lexer);
 
-            const parser = new PredicatedFooBarParser(tokenStream);
-            parser.expression();
+                const parser = new PredicatedFooBarParser(tokenStream);
+                parser.nonEmptyExpression();
 
-            const core = new c3.CodeCompletionCore(parser);
+                const core = new c3.CodeCompletionCore(parser);
 
-            // 1) At the input start.
-            let candidates = core.collectCandidates(0);
-            // delete workaround token
-            candidates.tokens.delete(PredicatedFooBarParser.EOF);
+                // 1) At the input start.
+                let candidates = core.collectCandidates(0);
+                // delete workaround token
+                candidates.tokens.delete(PredicatedFooBarParser.EOF);
 
-            expect(candidates.tokens.size, "Test 1").to.equal(1);
-            expect(candidates.tokens.has(PredicatedFooBarParser.FOO), "Test 2").to.equal(true);
-            expect(candidates.tokens.has(PredicatedFooBarParser.BAR), "Test 2").to.equal(false);
+                expect(candidates.tokens.size, "Test 1").to.equal(1);
+                expect(candidates.tokens.has(PredicatedFooBarParser.FOO), "Test 2").to.equal(true);
+                expect(candidates.tokens.has(PredicatedFooBarParser.BAR), "Test 2").to.equal(false);
+            }
+
+            {
+                const lexer = new PredicatedFooBarLexer(inputStream);
+
+                const tokenStream = new CommonTokenStream(lexer);
+
+                const parser = new PredicatedFooBarParser(tokenStream);
+                
+                parser.hasBar = true;   // enable the `bar`-rule
+                parser.nonEmptyExpression();
+
+                const core = new c3.CodeCompletionCore(parser);
+
+                // 1) At the input start.
+                let candidates = core.collectCandidates(0);
+                // delete workaround token
+                candidates.tokens.delete(PredicatedFooBarParser.EOF);
+
+                expect(candidates.tokens.size, "Test 1a").to.equal(2);
+                expect(candidates.tokens.has(PredicatedFooBarParser.FOO), "Test 2a").to.equal(true);
+                expect(candidates.tokens.has(PredicatedFooBarParser.BAR), "Test 2a").to.equal(true);
+            }
         });
 
-        it("PredicatedFooBar, bar-rule enabled", () => {
-            const lexer = new PredicatedFooBarLexer(inputStream);
-            lexer.hasBar = true;   // enable the `bar`-rule
+        it("`bar` enabled, then disabled", () => {
 
-            const tokenStream = new CommonTokenStream(lexer);
+            {
+                const lexer = new PredicatedFooBarLexer(inputStream);
 
-            const parser = new PredicatedFooBarParser(tokenStream);
+                const tokenStream = new CommonTokenStream(lexer);
+
+                const parser = new PredicatedFooBarParser(tokenStream);
+                
+                parser.hasBar = true;   // enable the `bar`-rule
+                parser.nonEmptyExpression();
+
+                const core = new c3.CodeCompletionCore(parser);
+
+                // 1) At the input start.
+                let candidates = core.collectCandidates(0);
+                // delete workaround token
+                candidates.tokens.delete(PredicatedFooBarParser.EOF);
+
+                expect(candidates.tokens.size, "Test 1").to.equal(2);
+                expect(candidates.tokens.has(PredicatedFooBarParser.FOO), "Test 2").to.equal(true);
+                expect(candidates.tokens.has(PredicatedFooBarParser.BAR), "Test 2").to.equal(true);
+            }
             
-            parser.hasBar = true;   // enable the `bar`-rule
-            parser.nonEmptyExpression();
+            {
+                const lexer = new PredicatedFooBarLexer(inputStream);
+                const tokenStream = new CommonTokenStream(lexer);
 
-            const core = new c3.CodeCompletionCore(parser);
+                const parser = new PredicatedFooBarParser(tokenStream);
+                parser.nonEmptyExpression();
 
-            // 1) At the input start.
-            let candidates = core.collectCandidates(0);
-            // delete workaround token
-            candidates.tokens.delete(PredicatedFooBarParser.EOF);
+                const core = new c3.CodeCompletionCore(parser);
 
-            expect(candidates.tokens.size, "Test 1a").to.equal(2);
-            expect(candidates.tokens.has(PredicatedFooBarParser.FOO), "Test 2a").to.equal(true);
-            expect(candidates.tokens.has(PredicatedFooBarParser.BAR), "Test 2a").to.equal(true);
+                // 1) At the input start.
+                let candidates = core.collectCandidates(0);
+                // delete workaround token
+                candidates.tokens.delete(PredicatedFooBarParser.EOF);
+
+                expect(candidates.tokens.size, "Test 1b").to.equal(1);
+                expect(candidates.tokens.has(PredicatedFooBarParser.FOO), "Test 2b").to.equal(true);
+                expect(candidates.tokens.has(PredicatedFooBarParser.BAR), "Test 2b").to.equal(false);
+            }
         });
 
     });


### PR DESCRIPTION
Make `CodeCompletionCore.followSetsByATN` a member variable.

Reason: when the grammar contains predicates, the completions depend on the initialization order of the parser (or lexer), and cannot be changed afterwards.