### PR TITLE
reduce java port dependency from antlr4 to antlr4-runtime

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -57,3 +57,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/02/10, kyle-painter, Kyle Painter, kpainter101@gmail.com
 2020/08/06, tamcgoey, Thomas McGoey-Smith, thomas@sourdough.dev
 2020/11/24, alessiostalla, Alessio Stalla, alessiostalla@gmail.com
+2022/11/08, XenoAmess, Jin Xu, xenoamess@gmail.com

--- a/ports/java/pom.xml
+++ b/ports/java/pom.xml
@@ -70,7 +70,7 @@
 
     <dependency>
       <groupId>org.antlr</groupId>
-      <artifactId>antlr4</artifactId>
+      <artifactId>antlr4-runtime</artifactId>
       <version>${antlr4.version}</version>
     </dependency>
     


### PR DESCRIPTION
it just does not need to.