### PR TITLE
Fix: (#23) Account for empty and fully-optional-body rules when collecting tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ jspm_packages
 .node_repl_history
 out
 
+# Optional vscode-antlr4 directory if plugin enabled
+.antlr
+
 # Generated files
 /ports/java/target/
 test/generated

--- a/contributors.txt
+++ b/contributors.txt
@@ -58,3 +58,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/08/06, tamcgoey, Thomas McGoey-Smith, thomas@sourdough.dev
 2020/11/24, alessiostalla, Alessio Stalla, alessiostalla@gmail.com
 2022/11/08, XenoAmess, Jin Xu, xenoamess@gmail.com
+2023/03/04, br0nstein, Aaron Braunstein, aa(last name)@gmail.com

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "scripts": {
         "prepublishOnly": "npm run test",
         "test": "tsc --version && npm run generate && tsc && npm run eslint && mocha out/test",
-        "generate": "antlr4ts test/CPP14.g4 test/Expr.g4 -no-listener -no-visitor -o test/generated -Xexact-output-dir",
+        "generate": "antlr4ts test/CPP14.g4 test/Expr.g4 test/Whitebox.g4 -no-listener -no-visitor -o test/generated -Xexact-output-dir",
         "eslint": "eslint ."
     },
     "dependencies": {

--- a/test/Whitebox.g4
+++ b/test/Whitebox.g4
@@ -1,0 +1,31 @@
+grammar Whitebox;
+
+@eader {
+/* eslint-disable @typescript-eslint/no-unused-vars, no-useless-escape */
+}
+
+test1: rule1 ADIPISCING ;
+rule1: rule2 CONSECTETUR ;
+rule2: LOREM rule3 rule5 SIT* AMET? ;
+rule3: rule4 DOLOR? ;
+rule4: IPSUM? ;
+rule5: ;
+
+test2: rule7 ADIPISCING ;
+rule7: rule8 CONSECTETUR ;
+rule8: LOREM rule11 rule9 SIT* AMET? ;
+rule9: rule10 DOLOR? ;
+rule10: IPSUM? ;
+rule11: ;
+
+test3: LOREM IPSUM? rule13 AMET+ CONSECTETUR ;
+rule13: (DOLOR | SIT)* ;
+
+LOREM: 'LOREM';
+IPSUM: 'IPSUM';
+DOLOR: 'DOLOR';
+SIT: 'SIT';
+AMET: 'AMET';
+CONSECTETUR: 'CONSECTETUR';
+ADIPISCING: 'ADIPISCING';
+WS: [ \n\r\t] -> skip;

--- a/test/test.ts
+++ b/test/test.ts
@@ -15,6 +15,8 @@ import { ExprParser } from "./generated/ExprParser";
 import { ExprLexer } from "./generated/ExprLexer";
 import { CPP14Parser } from "./generated/CPP14Parser";
 import { CPP14Lexer } from "./generated/CPP14Lexer";
+import { WhiteboxParser } from "./generated/WhiteboxParser";
+import { WhiteboxLexer } from "./generated/WhiteboxLexer";
 
 import * as c3 from "../index";
 
@@ -575,6 +577,79 @@ describe("antlr4-c3:", function () {
             expect(candidates.rules.get(ExprParser.RULE_assignment)?.startTokenIndex, "Test 6").to.equal(0);
             // The start token of the variableRef rule begins at token 'a'
             expect(candidates.rules.get(ExprParser.RULE_variableRef)?.startTokenIndex, "Test 7").to.equal(6);
+        });
+    });
+
+    describe("Whitebox grammar tests:", () => {
+
+        // Whitespace tokens are skipped
+
+        it("Caret at transition to rule with non-exhaustive follow set (optional tokens)", () => {
+            const inputStream = CharStreams.fromString("LOREM ");
+            const lexer = new WhiteboxLexer(inputStream);
+            const tokenStream = new CommonTokenStream(lexer);
+
+            const parser = new WhiteboxParser(tokenStream);
+            const errorListener = new ErrorListener();
+            parser.removeErrorListeners();
+            parser.addErrorListener(errorListener);
+            const ctx = parser.test1();
+            expect(errorListener.errorCount, "Test 1").equals(1);
+
+            const core = new c3.CodeCompletionCore(parser);
+            const candidates = core.collectCandidates(1, ctx); // caret on EOF
+
+            expect(candidates.tokens.size, "Test 2").to.equal(5);
+            expect(candidates.tokens.has(WhiteboxLexer.IPSUM), "Test 3").to.equal(true);
+            expect(candidates.tokens.has(WhiteboxLexer.DOLOR), "Test 4").to.equal(true);
+            expect(candidates.tokens.has(WhiteboxLexer.SIT), "Test 5").to.equal(true);
+            expect(candidates.tokens.has(WhiteboxLexer.AMET), "Test 6").to.equal(true);
+            expect(candidates.tokens.has(WhiteboxLexer.CONSECTETUR), "Test 7").to.equal(true);
+        });
+
+        it("Caret at transition to rule with empty follow set (epsilon-only transition to rule end)", () => {
+            const inputStream = CharStreams.fromString("LOREM ");
+            const lexer = new WhiteboxLexer(inputStream);
+            const tokenStream = new CommonTokenStream(lexer);
+
+            const parser = new WhiteboxParser(tokenStream);
+            const errorListener = new ErrorListener();
+            parser.removeErrorListeners();
+            parser.addErrorListener(errorListener);
+            const ctx = parser.test2();
+            expect(errorListener.errorCount, "Test 1").equals(1);
+
+            const core = new c3.CodeCompletionCore(parser);
+            const candidates = core.collectCandidates(1, ctx); // caret on EOF
+
+            expect(candidates.tokens.size, "Test 2").to.equal(5);
+            expect(candidates.tokens.has(WhiteboxLexer.IPSUM), "Test 3").to.equal(true);
+            expect(candidates.tokens.has(WhiteboxLexer.DOLOR), "Test 4").to.equal(true);
+            expect(candidates.tokens.has(WhiteboxLexer.SIT), "Test 5").to.equal(true);
+            expect(candidates.tokens.has(WhiteboxLexer.AMET), "Test 6").to.equal(true);
+            expect(candidates.tokens.has(WhiteboxLexer.CONSECTETUR), "Test 7").to.equal(true);
+        });
+
+        it("Caret at optional token", () => {
+            const inputStream = CharStreams.fromString("LOREM ");
+            const lexer = new WhiteboxLexer(inputStream);
+            const tokenStream = new CommonTokenStream(lexer);
+
+            const parser = new WhiteboxParser(tokenStream);
+            const errorListener = new ErrorListener();
+            parser.removeErrorListeners();
+            parser.addErrorListener(errorListener);
+            const ctx = parser.test3();
+            expect(errorListener.errorCount, "Test 1").equals(1);
+
+            const core = new c3.CodeCompletionCore(parser);
+            const candidates = core.collectCandidates(1, ctx); // caret on EOF
+
+            expect(candidates.tokens.size, "Test 2").to.equal(4);
+            expect(candidates.tokens.has(WhiteboxLexer.IPSUM), "Test 3").to.equal(true);
+            expect(candidates.tokens.has(WhiteboxLexer.DOLOR), "Test 4").to.equal(true);
+            expect(candidates.tokens.has(WhiteboxLexer.SIT), "Test 5").to.equal(true);
+            expect(candidates.tokens.has(WhiteboxLexer.AMET), "Test 6").to.equal(true);
         });
     });
 


### PR DESCRIPTION
Currently, collectCandidates does not return all possible tokens when it encounters rules that do not necessarily consume tokens. This is due to two reasons:
1) collectFollowSets does not proceed to states beyond the end of a rule transitioned to. This means that subsequent tokens within the rule are not collected even if the rule transition is to a rule with fully-optional tokens or no tokens at all.
2) processRule always returns an empty-set RuleEndStatus when at the caret position. This means that tokens from subsequent transitions are not collected, even if the processed rule could reach the rule end state without consuming tokens.

This PR fixes both issues by adding property isExhaustive to the follow sets object to represent whether the collected follow sets represent all possible tokens that can follow, or if subsequent transitions need to be followed to further collect tokens, and using that to further collect follow sets within the processed rule after the rule transition and after the processed rule. Also, it removes the use of the epsilon token when collecting follow sets and refactors code to use isExhaustive property instead, ensuring that the epsilon token is never returned in the candidate tokens list.

Fixes mike-lischke/antlr4-c3#23