### PR TITLE
Handle condition where tokenStream.get() returns undefined

### DIFF
--- a/src/CodeCompletionCore.ts
+++ b/src/CodeCompletionCore.ts
@@ -180,6 +180,9 @@ export class CodeCompletionCore {
         let offset = this.tokenStartIndex;
         while (true) {
             const token = tokenStream.get(offset++);
+            if (!token) {
+                break;
+            }
             if (token.channel === Token.DEFAULT_CHANNEL) {
                 this.tokens.push(token);
 


### PR DESCRIPTION
When the document isn't fully parseable, the token stream will return undefined. This change allows the completion core to recover