### PR TITLE
build: add --keep-names option to build command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "antlr4-c3",
-    "version": "3.3.5",
+    "version": "3.3.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "antlr4-c3",
-            "version": "3.3.5",
+            "version": "3.3.6",
             "license": "MIT",
             "dependencies": {
                 "antlr4ng": "2.0.10"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "test": "node --no-warnings --experimental-vm-modules node_modules/jest/bin/jest.js --no-coverage",
         "generate": "antlr4ng -Dlanguage=TypeScript tests/CPP14.g4 tests/Expr.g4 tests/Whitebox.g4 -no-listener -no-visitor -o tests/generated -Xexact-output-dir",
         "eslint": "eslint .",
-        "esbuild": "esbuild ./index.ts --bundle --outfile=lib/index.mjs --format=esm --sourcemap=external --packages=external"
+        "esbuild": "esbuild ./index.ts --bundle --outfile=lib/index.mjs --format=esm --sourcemap=external --packages=external --keep-names"
     },
     "devDependencies": {
         "@types/jest": "29.5.12",


### PR DESCRIPTION
To fix the same issue as it https://github.com/mike-lischke/antlr4ng/issues/38

Please refer to https://github.com/mike-lischke/antlr4ng/pull/41 for related changes.

Also updated the package.lock file, It looks like the last time you bump the version, you forgot to update this file at the same time.

