### PR TITLE
Fix invalid Java unit test assertion

### DIFF
--- a/ports/java/src/test/java/com/vmware/antlr4c3/TestCodeCompletionCore.java
+++ b/ports/java/src/test/java/com/vmware/antlr4c3/TestCodeCompletionCore.java
@@ -20,16 +20,13 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.atn.PredictionMode;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
-import org.junit.runners.MethodSorters;
 
 import static org.junit.Assert.*;
 
 /**
  * Unit tests for CodeCompletionCore
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestCodeCompletionCore {
 
     private static final Logger logger = Logger.getLogger(TestCodeCompletionCore.class.getName());
@@ -153,8 +150,8 @@ public class TestCodeCompletionCore {
         assertTrue(candidates.tokens.containsKey(ExprLexer.VAR));
         assertTrue(candidates.tokens.containsKey(ExprLexer.LET));
 
-        assertEquals(Arrays.asList(new Integer[]{ExprLexer.ID, ExprLexer.EQUAL}), candidates.tokens.get(ExprLexer.VAR));
-        assertEquals(Arrays.asList(new Integer[]{ExprLexer.ID, ExprLexer.EQUAL}), candidates.tokens.get(ExprLexer.LET));
+        assertEquals(Arrays.asList(new Integer[]{}), candidates.tokens.get(ExprLexer.VAR));
+        assertEquals(Arrays.asList(new Integer[]{}), candidates.tokens.get(ExprLexer.LET));
 
         // 2) On the variable name ('c').
         candidates = core.collectCandidates(2, null);


### PR DESCRIPTION
Fix invalid Java unit test assertion. C3 should not suggest ignored tokens as completions.

See issue #77 for related discussion.

This invalid assertion was hiding a bug in C3. How to fix that bug is up for discussion, but basically it appears that the implementation of the `followSetsByATN` global cache is problematic. This cache is based on the class name of the parser object, but it does not account for ignored tokens. Two instances of `CodeCompletionCore` will use the same `followSetsByATN` entry for the same parser, even if they have different ignored tokens. How to fix this?

The other language implementations of C3 may have the same problem. For example, it looks to me like the C# tests have the same invalid assertion. I'm not sure I want to touch that, though, because I'm not familiar with C#. So this PR just addresses the Java port.

I'm also wondering if this is related to #66 as well. @mike-lischke is the expert here.