### PR TITLE
#132 #136 C++ port light refactororing and bug fix

### DIFF
--- a/ports/cpp/.clang-tidy
+++ b/ports/cpp/.clang-tidy
@@ -20,3 +20,44 @@ ImplementationFileExtensions:
 HeaderFilterRegex: ''
 FormatStyle: '.clang-format'
 SystemHeaders: false
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassMemberCase
+    value: camelBack
+  - key: readability-identifier-naming.ConstexprVariableCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.StaticConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.StaticVariableCase
+    value: camelBack
+  - key: readability-identifier-naming.MacroDefinitionCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.MacroDefinitionIgnoredRegexp
+    value: '^[A-Z]+(_[A-Z]+)*_$'
+  - key: readability-identifier-naming.MemberCase
+    value: camelBack
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: ''
+  - key: readability-identifier-naming.PublicMemberSuffix
+    value: ''
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.ParameterCase
+    value: camelBack
+  - key: readability-identifier-naming.TypeAliasCase
+    value: CamelCase
+  - key: readability-identifier-naming.TypedefCase
+    value: CamelCase
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack
+  - key: readability-identifier-naming.IgnoreMainLikeFunctions
+    value: 1

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -57,7 +57,7 @@ std::vector<size_t> longestCommonPrefix(
 
 }  // namespace
 
-std::map<std::type_index, CodeCompletionCore::FollowSetsPerState>  // NOLINT
+std::unordered_map<std::type_index, CodeCompletionCore::FollowSetsPerState>  // NOLINT
     CodeCompletionCore::followSetsByATN = {};
 
 // Matches ATNStateType enum
@@ -491,7 +491,7 @@ CodeCompletionCore::RuleEndStatus CodeCompletionCore::processRule(  // NOLINT
   // Start with rule specific handling before going into the ATN walk.
 
   // Check first if we've taken this path with the same input before.
-  std::map<size_t, RuleEndStatus>& positionMap = shortcutMap[startState->ruleIndex];
+  std::unordered_map<size_t, RuleEndStatus>& positionMap = shortcutMap[startState->ruleIndex];
   if (positionMap.contains(tokenListIndex)) {
     if (showDebugOutput) {
       std::cout << "=====> shortcut" << "\n";

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -113,7 +113,7 @@ CandidatesCollection CodeCompletionCore::collectCandidates(  // NOLINT
     if (token->getChannel() == antlr4::Token::DEFAULT_CHANNEL) {
       tokens.push_back(token);
 
-      if (token->getTokenIndex() >= caretTokenIndex || token->getType() == antlr4::Token::EOF) {
+      if (token->getTokenIndex() >= caretTokenIndex) {
         break;
       }
     }

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -491,18 +491,12 @@ CodeCompletionCore::RuleEndStatus CodeCompletionCore::processRule(  // NOLINT
   // Start with rule specific handling before going into the ATN walk.
 
   // Check first if we've taken this path with the same input before.
-  std::map<size_t, RuleEndStatus> positionMap;
-  if (!shortcutMap.contains(startState->ruleIndex)) {
-    shortcutMap[startState->ruleIndex] = positionMap;
-  } else {
-    positionMap = shortcutMap[startState->ruleIndex];
-    if (positionMap.contains(tokenListIndex)) {
-      if (showDebugOutput) {
-        std::cout << "=====> shortcut" << "\n";
-      }
-
-      return positionMap[tokenListIndex];
+  std::map<size_t, RuleEndStatus>& positionMap = shortcutMap[startState->ruleIndex];
+  if (positionMap.contains(tokenListIndex)) {
+    if (showDebugOutput) {
+      std::cout << "=====> shortcut" << "\n";
     }
+    return positionMap[tokenListIndex];
   }
 
   RuleEndStatus result;
@@ -521,7 +515,7 @@ CodeCompletionCore::RuleEndStatus CodeCompletionCore::processRule(  // NOLINT
     antlr4::atn::RuleStopState* stop = atn.ruleToStopState[startState->ruleIndex];
     setsPerState[startState->stateNumber] = determineFollowSets(startState, stop);
   }
-  
+
   const FollowSetsHolder& followSets = setsPerState[startState->stateNumber];
 
   // Get the token index where our rule starts from our (possibly filtered)

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -55,11 +55,11 @@ std::vector<size_t> longestCommonPrefix(std::vector<size_t> lhs, std::vector<siz
 
 }  // namespace
 
-std::map<std::type_index, FollowSetsPerState>  // NOLINT
-    c3::CodeCompletionCore::followSetsByATN = {};
+std::map<std::type_index, CodeCompletionCore::FollowSetsPerState>  // NOLINT
+    CodeCompletionCore::followSetsByATN = {};
 
 // Matches ATNStateType enum
-std::vector<std::string> c3::CodeCompletionCore::atnStateTypeMap  // NOLINT
+std::vector<std::string> CodeCompletionCore::atnStateTypeMap  // NOLINT
     {
         "invalid",
         "basic",
@@ -331,7 +331,7 @@ std::vector<size_t> CodeCompletionCore::getFollowingTokens(const antlr4::atn::Tr
  * @param stop Stop state.
  * @returns Follow sets.
  */
-FollowSetsHolder CodeCompletionCore::determineFollowSets(
+CodeCompletionCore::FollowSetsHolder CodeCompletionCore::determineFollowSets(
     antlr4::atn::ATNState* start, antlr4::atn::ATNState* stop
 ) {
   std::vector<FollowSetWithPath> sets = {};
@@ -466,7 +466,7 @@ bool CodeCompletionCore::collectFollowSets(  // NOLINT
  * @returns the set of token stream indexes (which depend on the ways that had
  * to be taken).
  */
-RuleEndStatus CodeCompletionCore::processRule(  // NOLINT
+CodeCompletionCore::RuleEndStatus CodeCompletionCore::processRule(  // NOLINT
     antlr4::atn::RuleStartState* startState,
     size_t tokenListIndex,
     RuleWithStartTokenList& callStack,

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -287,26 +287,27 @@ bool CodeCompletionCore::translateToRuleIndex(
  */
 std::vector<size_t> CodeCompletionCore::getFollowingTokens(const antlr4::atn::Transition* transition
 ) const {
-  std::vector<size_t> result = {};
-
+  std::vector<size_t> result;
   std::vector<antlr4::atn::ATNState*> pipeline = {transition->target};
 
   while (!pipeline.empty()) {
     antlr4::atn::ATNState* state = pipeline.back();
     pipeline.pop_back();
 
-    if (state != nullptr) {
-      for (const antlr4::atn::ConstTransitionPtr& outgoing : state->transitions) {
-        if (outgoing->getTransitionType() == antlr4::atn::TransitionType::ATOM) {
-          if (!outgoing->isEpsilon()) {
-            const auto list = outgoing->label();
-            if (list.size() == 1 && !ignoredTokens.contains(list.get(0))) {
-              result.push_back(list.get(0));
-              pipeline.push_back(outgoing->target);
-            }
-          } else {
+    if (state == nullptr) {
+      continue;
+    }
+
+    for (const antlr4::atn::ConstTransitionPtr& outgoing : state->transitions) {
+      if (outgoing->getTransitionType() == antlr4::atn::TransitionType::ATOM) {
+        if (!outgoing->isEpsilon()) {
+          const auto list = outgoing->label();
+          if (list.size() == 1 && !ignoredTokens.contains(list.get(0))) {
+            result.push_back(list.get(0));
             pipeline.push_back(outgoing->target);
           }
+        } else {
+          pipeline.push_back(outgoing->target);
         }
       }
     }

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -127,13 +127,11 @@ CandidatesCollection CodeCompletionCore::collectCandidates(  // NOLINT
 
   RuleWithStartTokenList callStack = {};
   const size_t startRule = (context != nullptr) ? context->getRuleIndex() : 0;
-  bool cancelled = false;
 
-  processRule(atn.ruleToStartState[startRule], 0, callStack, 0, 0, cancelled);
-  candidates.cancelled = cancelled;
+  processRule(atn.ruleToStartState[startRule], 0, callStack, 0, 0, candidates.cancelled);
 
   if (showResult) {
-    if (cancelled) {
+    if (candidates.cancelled) {
       std::cout << "*** TIMED OUT ***\n";
     }
 

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -233,12 +233,11 @@ bool CodeCompletionCore::translateToRuleIndex(
     // but only if there isn't already an entry like that.
     std::vector<size_t> path;
     path.reserve(index);
-    for (size_t subrangeIndex = 0; subrangeIndex < index; subrangeIndex++) {
-      path.push_back(ruleWithStartTokenList[subrangeIndex].ruleIndex);
+    for (size_t i = 0; i < index; i++) {
+      path.push_back(ruleWithStartTokenList[i].ruleIndex);
     }
 
     bool addNew = true;
-
     for (auto const& [cRuleEntryRuleIndex, cRuleEntryCandidateRule] : candidates.rules) {
       if (cRuleEntryRuleIndex != rwst.ruleIndex ||
           cRuleEntryCandidateRule.ruleList.size() != path.size()) {
@@ -246,13 +245,14 @@ bool CodeCompletionCore::translateToRuleIndex(
       }
 
       // Found an entry for this rule. Same path?
-      bool samePath = true;
-      for (size_t pathI = 0; pathI < path.size(); pathI++) {
-        if (path[pathI] == cRuleEntryCandidateRule.ruleList[pathI]) {
-          samePath = false;
-          break;
+      const bool samePath = [&] {
+        for (size_t i = 0; i < path.size(); i++) {
+          if (path[i] == cRuleEntryCandidateRule.ruleList[i]) {
+            return false;
+          }
         }
-      }
+        return true;
+      }();
 
       // If same path, then don't add a new (duplicate) entry.
       if (samePath) {

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -109,7 +109,7 @@ CandidatesCollection CodeCompletionCore::collectCandidates(  // NOLINT
   tokens = {};
   size_t offset = tokenStartIndex;
   while (true) {
-    antlr4::Token* token = tokenStream->get(offset++);
+    const antlr4::Token* token = tokenStream->get(offset++);
     if (token->getChannel() == antlr4::Token::DEFAULT_CHANNEL) {
       tokens.push_back(token);
 

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
@@ -5,8 +5,8 @@
 //  Licensed under the MIT License.
 //
 
-#ifndef CodeCompletionCore_hpp
-#define CodeCompletionCore_hpp
+#ifndef CODE_COMPLETION_CORE_HPP
+#define CODE_COMPLETION_CORE_HPP
 
 #include <Parser.h>
 #include <ParserRuleContext.h>

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
@@ -93,7 +93,7 @@ private:
     bool isExhaustive;
   };
 
-  using FollowSetsPerState = std::map<size_t, FollowSetsHolder>;
+  using FollowSetsPerState = std::unordered_map<size_t, FollowSetsHolder>;
 
   /** Token stream position info after a rule was processed. */
   using RuleEndStatus = std::unordered_set<size_t>;
@@ -174,7 +174,7 @@ public:
   // Private
   // --------------------------------------------------------
 private:
-  static std::map<std::type_index, FollowSetsPerState> followSetsByATN;
+  static std::unordered_map<std::type_index, FollowSetsPerState> followSetsByATN;
   static std::vector<std::string> atnStateTypeMap;
 
   antlr4::Parser* parser;
@@ -192,7 +192,7 @@ private:
    * A rule which has been visited before with the same input position will
    * always produce the same output positions.
    */
-  std::map<size_t, std::map<size_t, RuleEndStatus>> shortcutMap;
+  std::unordered_map<size_t, std::unordered_map<size_t, RuleEndStatus>> shortcutMap;
 
   /** The collected candidates (rules and tokens). */
   c3::CandidatesCollection candidates;

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
@@ -35,6 +35,8 @@ using RuleList = std::vector<size_t>;
 struct CandidateRule {
   size_t startTokenIndex;
   RuleList ruleList;
+
+  friend bool operator==(const CandidateRule& lhs, const CandidateRule& rhs) = default;
 };
 
 /**
@@ -49,6 +51,9 @@ struct CandidatesCollection {
   std::map<size_t, TokenList> tokens;
   std::map<size_t, CandidateRule> rules;
   bool cancelled;
+
+  friend bool operator==(const CandidatesCollection& lhs, const CandidatesCollection& rhs) =
+      default;
 };
 
 class CodeCompletionCore {

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
@@ -23,6 +23,7 @@
 #include <map>
 #include <string>
 #include <typeindex>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
@@ -5,8 +5,7 @@
 //  Licensed under the MIT License.
 //
 
-#ifndef CODE_COMPLETION_CORE_HPP
-#define CODE_COMPLETION_CORE_HPP
+#pragma once
 
 #include <Parser.h>
 #include <ParserRuleContext.h>
@@ -246,5 +245,3 @@ private:
 };
 
 }  // namespace c3
-
-#endif /* CodeCompletionCore_hpp */

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
@@ -181,7 +181,7 @@ private:
   antlr4::atn::ATN const& atn;                // NOLINT: reference field
   antlr4::dfa::Vocabulary const& vocabulary;  // NOLINT: reference field
   std::vector<std::string> const& ruleNames;  // NOLINT: reference field
-  std::vector<antlr4::Token*> tokens;
+  std::vector<const antlr4::Token*> tokens;
   std::vector<int> precedenceStack;
 
   size_t tokenStartIndex = 0;

--- a/ports/cpp/test/cpp14/Cpp14Test.cpp
+++ b/ports/cpp/test/cpp14/Cpp14Test.cpp
@@ -161,8 +161,7 @@ TEST(CPP14Parser, SimpleExample) {  // NOLINT: complexity
         CPP14Parser::RuleTranslationunit,
         CPP14Parser::RuleDeclarationseq,
         CPP14Parser::RuleDeclaration,
-        CPP14Parser::RuleBlockdeclaration,   // TS: +- `RuleFunctiondefinition`
-        CPP14Parser::RuleSimpledeclaration,  // TS: --
+        CPP14Parser::RuleFunctiondefinition,
         CPP14Parser::RuleDeclspecifierseq,
         CPP14Parser::RuleDeclspecifier,
         CPP14Parser::RuleTypespecifier,

--- a/ports/cpp/test/expr/ExprTest.cpp
+++ b/ports/cpp/test/expr/ExprTest.cpp
@@ -210,4 +210,17 @@ TEST(SimpleExpressionParser, CandidateRulesWithDifferentStartTokens) {
   }
 }
 
+TEST(SimpleExpressionParser, OutOfBoundsCaret) {
+  AntlrPipeline<ExprGrammar> pipeline("var c = a + b");
+  pipeline.tokens.fill();
+
+  c3::CodeCompletionCore completion(&pipeline.parser);
+  const auto last = completion.collectCandidates(7);
+  ASSERT_EQ(last, completion.collectCandidates(7));
+  ASSERT_EQ(last, completion.collectCandidates(8));
+  ASSERT_EQ(last, completion.collectCandidates(16));
+  ASSERT_EQ(last, completion.collectCandidates(32));
+  ASSERT_EQ(last, completion.collectCandidates(128));
+}
+
 }  // namespace c3::test


### PR DESCRIPTION
- Added Clang-Tidy identifier naming rules
- [Fix CppParser::SimpleExample test](https://github.com/mike-lischke/antlr4-c3/pull/140/commits/f32f9a2f66f85b3a1f6053a914656060497f1cc7)
- Did small refactorings, reduced copy-constructor calls
- Speed up x2