### PR TITLE
#132 Change C++ port public API

### DIFF
--- a/ports/cpp/CMakeLists.txt
+++ b/ports/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
-project(antlr4-c3 VERSION 1.1.0)
+project(antlr4-c3 VERSION 2.0.0)
 
 option(ANTLR4C3_DEVELOPER "Enable ${PROJECT_NAME} developer mode" OFF)
 

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -131,7 +131,7 @@ CandidatesCollection CodeCompletionCore::collectCandidates(
 
   processRule(atn.ruleToStartState[startRule], 0, callStack, 0, 0, candidates.isCancelled);
 
-  if (showResult) {
+  if (debugOptions.showResult) {
     if (candidates.isCancelled) {
       std::cout << "*** TIMED OUT ***\n";
     }
@@ -266,7 +266,7 @@ bool CodeCompletionCore::translateToRuleIndex(
           .startTokenIndex = rwst.startTokenIndex,
           .ruleList = path,
       };
-      if (showDebugOutput) {
+      if (debugOptions.showDebugOutput) {
         std::cout << "=====> collected: " << ruleNames[rwst.ruleIndex] << "\n";
       }
     }
@@ -481,7 +481,7 @@ CodeCompletionCore::RuleEndStatus CodeCompletionCore::processRule(  // NOLINT
   // Check first if we've taken this path with the same input before.
   std::unordered_map<size_t, RuleEndStatus>& positionMap = shortcutMap[startState->ruleIndex];
   if (positionMap.contains(tokenListIndex)) {
-    if (showDebugOutput) {
+    if (debugOptions.showDebugOutput) {
       std::cout << "=====> shortcut" << "\n";
     }
     return positionMap[tokenListIndex];
@@ -538,7 +538,7 @@ CodeCompletionCore::RuleEndStatus CodeCompletionCore::processRule(  // NOLINT
         if (!translateStackToRuleIndex(fullPath)) {
           for (const size_t symbol : set.intervals.toList()) {
             if (!ignoredTokens.contains(symbol)) {
-              if (showDebugOutput) {
+              if (debugOptions.showDebugOutput) {
                 std::cout << "=====> collected: " << vocabulary.getDisplayName(symbol) << "\n";
               }
               if (!candidates.tokens.contains(symbol)) {
@@ -602,14 +602,14 @@ CodeCompletionCore::RuleEndStatus CodeCompletionCore::processRule(  // NOLINT
     const size_t currentSymbol = tokens[currentEntry.tokenListIndex]->getType();
 
     const bool atCaret = currentEntry.tokenListIndex >= tokens.size() - 1;
-    if (showDebugOutput) {
+    if (debugOptions.showDebugOutput) {
       printDescription(
           indentation,
           currentEntry.state,
           generateBaseDescription(currentEntry.state),
           currentEntry.tokenListIndex
       );
-      if (showRuleStack) {
+      if (debugOptions.showRuleStack) {
         printRuleState(callStack);
       }
     }
@@ -720,7 +720,7 @@ CodeCompletionCore::RuleEndStatus CodeCompletionCore::processRule(  // NOLINT
                 const bool hasTokenSequence = list.size() == 1;
                 for (const size_t symbol : list) {
                   if (!ignoredTokens.contains(symbol)) {
-                    if (showDebugOutput) {
+                    if (debugOptions.showDebugOutput) {
                       std::cout << "=====> collected: " << vocabulary.getDisplayName(symbol)
                                 << "\n";
                     }
@@ -741,7 +741,7 @@ CodeCompletionCore::RuleEndStatus CodeCompletionCore::processRule(  // NOLINT
               }
             } else {
               if (set.contains(currentSymbol)) {
-                if (showDebugOutput) {
+                if (debugOptions.showDebugOutput) {
                   std::cout << "=====> consumed: " << vocabulary.getDisplayName(currentSymbol)
                             << "\n";
                 }
@@ -768,10 +768,6 @@ CodeCompletionCore::RuleEndStatus CodeCompletionCore::processRule(  // NOLINT
   return result;
 }
 
-// ----------------------------------------------------------------------------
-// MARK: - Debug
-// ----------------------------------------------------------------------------
-
 std::string CodeCompletionCore::generateBaseDescription(antlr4::atn::ATNState* state) {
   const std::string stateValue = (state->stateNumber == antlr4::atn::ATNState::INVALID_STATE_NUMBER)
                                      ? "Invalid"
@@ -794,7 +790,7 @@ void CodeCompletionCore::printDescription(
   const auto indent = std::string(indentation * 2, ' ');
 
   std::string transitionDescription;
-  if (debugOutputWithTransitions) {
+  if (debugOptions.showTransitions) {
     for (const antlr4::atn::ConstTransitionPtr& transition : state->transitions) {
       std::string labels;
       std::vector<ptrdiff_t> symbols = transition->label().toList();

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -30,7 +30,6 @@
 #include <iostream>
 #include <iterator>
 #include <ranges>
-#include <ratio>
 #include <set>
 #include <sstream>
 #include <string>
@@ -95,13 +94,13 @@ CandidatesCollection CodeCompletionCore::collectCandidates(
   const auto* context = parameters.context;
 
   timeout = parameters.timeout;
-  cancel = parameters.cancel;
+  cancel = parameters.isCancelled;
   timeoutStart = std::chrono::steady_clock::now();
 
   shortcutMap.clear();
   candidates.rules.clear();
   candidates.tokens.clear();
-  candidates.cancelled = false;
+  candidates.isCancelled = false;
   statesProcessed = 0;
   precedenceStack = {};
 
@@ -130,10 +129,10 @@ CandidatesCollection CodeCompletionCore::collectCandidates(
   RuleWithStartTokenList callStack = {};
   const size_t startRule = (context != nullptr) ? context->getRuleIndex() : 0;
 
-  processRule(atn.ruleToStartState[startRule], 0, callStack, 0, 0, candidates.cancelled);
+  processRule(atn.ruleToStartState[startRule], 0, callStack, 0, 0, candidates.isCancelled);
 
   if (showResult) {
-    if (candidates.cancelled) {
+    if (candidates.isCancelled) {
       std::cout << "*** TIMED OUT ***\n";
     }
 

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
@@ -50,7 +50,7 @@ struct CandidateRule {
 struct CandidatesCollection {
   std::map<size_t, TokenList> tokens;
   std::map<size_t, CandidateRule> rules;
-  bool cancelled;
+  bool isCancelled;
 
   friend bool operator==(const CandidatesCollection& lhs, const CandidatesCollection& rhs) =
       default;
@@ -71,7 +71,7 @@ struct Parameters {
    * true while the function is executing, then collecting candidates will abort
    * as soon as possible.
    */
-  std::atomic<bool>* cancel = nullptr;
+  std::atomic<bool>* isCancelled = nullptr;
 };
 
 class CodeCompletionCore {

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
@@ -10,6 +10,7 @@
 #include <Parser.h>
 #include <ParserRuleContext.h>
 #include <Token.h>
+#include <Vocabulary.h>
 #include <atn/ATNState.h>
 #include <atn/PredicateTransition.h>
 #include <atn/RuleStartState.h>
@@ -20,6 +21,7 @@
 #include <chrono>
 #include <cstddef>
 #include <map>
+#include <optional>
 #include <string>
 #include <typeindex>
 #include <unordered_map>
@@ -243,6 +245,8 @@ private:
       size_t indentation,
       bool& timedOut
   );
+
+  antlr4::misc::IntervalSet allUserTokens() const;
 
   std::string generateBaseDescription(antlr4::atn::ATNState* state);
 

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
@@ -194,9 +194,9 @@ private:
   static std::vector<std::string> atnStateTypeMap;
 
   antlr4::Parser* parser;
-  antlr4::atn::ATN const& atn;                // NOLINT: reference field
-  antlr4::dfa::Vocabulary const& vocabulary;  // NOLINT: reference field
-  std::vector<std::string> const& ruleNames;  // NOLINT: reference field
+  const antlr4::atn::ATN* atn;
+  const antlr4::dfa::Vocabulary* vocabulary;
+  const std::vector<std::string>* ruleNames;
   std::vector<const antlr4::Token*> tokens;
   std::vector<int> precedenceStack;
 

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
@@ -74,6 +74,31 @@ struct Parameters {
   std::atomic<bool>* isCancelled = nullptr;
 };
 
+struct DebugOptions {
+  /**
+   * Not dependent on showDebugOutput.
+   * Prints the collected rules + tokens to terminal.
+   */
+  bool showResult = false;
+
+  /**
+   * Enables printing ATN state info to terminal.
+   */
+  bool showDebugOutput = false;
+
+  /**
+   * Only relevant when showDebugOutput is true.
+   * Enables transition printing for a state.
+   */
+  bool showTransitions = false;
+
+  /**
+   * Only relevant when showDebugOutput is true.
+   * Enables call stack printing for each rule recursion.
+   */
+  bool showRuleStack = false;
+};
+
 class CodeCompletionCore {
 private:
   struct PipelineEntry {
@@ -143,29 +168,10 @@ public:
    */
   bool translateRulesTopDown = false;  // NOLINT: public field
 
-  // --------------------------------------------------------
-  // Debugging Options
-  // --------------------------------------------------------
-  // Print human readable ATN state and other info.
-
-  /** Not dependent on showDebugOutput. Prints the collected rules + tokens to
-   * terminal. */
-  bool showResult = false;  // NOLINT: public field
-
-  /** Enables printing ATN state info to terminal. */
-  bool showDebugOutput = false;  // NOLINT: public field
-
-  /** Only relevant when showDebugOutput is true. Enables transition printing
-   * for a state. */
-  bool debugOutputWithTransitions = false;  // NOLINT: public field
-
-  /** Also depends on showDebugOutput. Enables call stack printing for each rule
-   * recursion. */
-  bool showRuleStack = false;  // NOLINT: public field
-
-  // --------------------------------------------------------
-  // Usage
-  // --------------------------------------------------------
+  /**
+   * Print human readable ATN state and other info.
+   */
+  DebugOptions debugOptions;  // NOLINT: public field
 
   /**
    * This is the main entry point. The caret token index specifies the token
@@ -183,9 +189,6 @@ public:
    */
   CandidatesCollection collectCandidates(size_t caretTokenIndex, Parameters parameters = {});
 
-  // --------------------------------------------------------
-  // Private
-  // --------------------------------------------------------
 private:
   static std::unordered_map<std::type_index, FollowSetsPerState> followSetsByATN;
   static std::vector<std::string> atnStateTypeMap;

--- a/ports/cpp/test/whitebox/WhiteboxTest.cpp
+++ b/ports/cpp/test/whitebox/WhiteboxTest.cpp
@@ -24,7 +24,7 @@ TEST(WhiteboxGrammarTests, CaretAtTransitionToRuleWithNonExhaustiveFollowSet) {
   EXPECT_EQ(pipeline.listener.GetErrorCount(), 1);
 
   c3::CodeCompletionCore completion(&pipeline.parser);
-  auto candidates = completion.collectCandidates(1, ctx);
+  auto candidates = completion.collectCandidates(1, {ctx});
 
   EXPECT_THAT(
       Keys(candidates.tokens),
@@ -45,7 +45,7 @@ TEST(WhiteboxGrammarTests, CaretAtTransitionToRuleWithEmptyFollowSet) {
   EXPECT_EQ(pipeline.listener.GetErrorCount(), 1);
 
   c3::CodeCompletionCore completion(&pipeline.parser);
-  auto candidates = completion.collectCandidates(1, ctx);
+  auto candidates = completion.collectCandidates(1, {ctx});
 
   EXPECT_THAT(
       Keys(candidates.tokens),
@@ -79,7 +79,7 @@ TEST(WhiteboxGrammarTests, CaretAtOneOfMultiplePossibleStates) {
     }();
 
     c3::CodeCompletionCore completion(&pipeline.parser);
-    auto candidates = completion.collectCandidates(2, ctx);
+    auto candidates = completion.collectCandidates(2, {ctx});
 
     EXPECT_THAT(Keys(candidates.tokens), UnorderedElementsAre(WhiteboxLexer::DOLOR));
     EXPECT_THAT(candidates.tokens[WhiteboxLexer::DOLOR], UnorderedElementsAre());
@@ -92,7 +92,7 @@ TEST(WhiteboxGrammarTests, CaretAtOneOfMultiplePossibleStatesWithCommonFollowLis
   auto* ctx = pipeline.parser.test8();
 
   c3::CodeCompletionCore completion(&pipeline.parser);
-  auto candidates = completion.collectCandidates(2, ctx);
+  auto candidates = completion.collectCandidates(2, {ctx});
 
   EXPECT_THAT(Keys(candidates.tokens), UnorderedElementsAre(WhiteboxLexer::DOLOR));
   EXPECT_THAT(candidates.tokens[WhiteboxLexer::DOLOR], UnorderedElementsAre(WhiteboxLexer::SIT));


### PR DESCRIPTION
- Introduced an optional parameters pack for `collectCandidates`. Because current API is not so convenient for usage of only a part of arguments.

- Did hide `preferredRules` and `ignoredTokens` under setters. This will provide us an ability to change internal data structures to improve performance (I'm thinking about using `BitSet`, because it is more cache friendly while there are not, so many token types in average generated parser).

- Renamed some variables.

- Raised port version to `2.0.0` because of API breaking changes.