### PR TITLE
#136 Remove FollowSet cache dependency on ignoredTokens

### DIFF
--- a/ports/cpp/ci/test.sh
+++ b/ports/cpp/ci/test.sh
@@ -8,8 +8,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-exit 0 # https://github.com/mike-lischke/antlr4-c3/issues/136
-
 set -e
 
 TESTS="

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -138,39 +138,7 @@ CandidatesCollection CodeCompletionCore::collectCandidates(
     following.erase(std::begin(removed), std::end(removed));
   }
 
-  if (debugOptions.showResult) {
-    if (candidates.isCancelled) {
-      std::cout << "*** TIMED OUT ***\n";
-    }
-
-    std::cout << "States processed: " << statesProcessed << "\n\n";
-
-    std::cout << "Collected rules:\n";
-    for (const auto& [tokenIndex, rule] : candidates.rules) {
-      std::cout << ruleNames->at(tokenIndex);
-      std::cout << ", path: ";
-
-      for (const size_t token : rule.ruleList) {
-        std::cout << ruleNames->at(token) << " ";
-      }
-    }
-    std::cout << "\n\n";
-
-    std::set<std::string> sortedTokens;
-    for (const auto& [token, tokenList] : candidates.tokens) {
-      std::string value = vocabulary->getDisplayName(token);
-      for (const size_t following : tokenList) {
-        value += " " + vocabulary->getDisplayName(following);
-      }
-      sortedTokens.emplace(value);
-    }
-
-    std::cout << "Collected tokens:\n";
-    for (const std::string& symbol : sortedTokens) {
-      std::cout << symbol;
-    }
-    std::cout << "\n\n";
-  }
+  printOverallResults();
 
   return candidates;
 }
@@ -855,6 +823,42 @@ void CodeCompletionCore::printRuleState(RuleWithStartTokenList const& stack) {
     std::cout << ruleNames->at(rule.ruleIndex);
   }
   std::cout << "\n";
+}
+
+void CodeCompletionCore::printOverallResults() {
+  if (debugOptions.showResult) {
+    if (candidates.isCancelled) {
+      std::cout << "*** TIMED OUT ***\n";
+    }
+
+    std::cout << "States processed: " << statesProcessed << "\n\n";
+
+    std::cout << "Collected rules:\n";
+    for (const auto& [tokenIndex, rule] : candidates.rules) {
+      std::cout << ruleNames->at(tokenIndex);
+      std::cout << ", path: ";
+
+      for (const size_t token : rule.ruleList) {
+        std::cout << ruleNames->at(token) << " ";
+      }
+    }
+    std::cout << "\n\n";
+
+    std::set<std::string> sortedTokens;
+    for (const auto& [token, tokenList] : candidates.tokens) {
+      std::string value = vocabulary->getDisplayName(token);
+      for (const size_t following : tokenList) {
+        value += " " + vocabulary->getDisplayName(following);
+      }
+      sortedTokens.emplace(value);
+    }
+
+    std::cout << "Collected tokens:\n";
+    for (const std::string& symbol : sortedTokens) {
+      std::cout << symbol;
+    }
+    std::cout << "\n\n";
+  }
 }
 
 }  // namespace c3

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -286,7 +286,7 @@ bool CodeCompletionCore::translateToRuleIndex(
  * @returns A list of toke types.
  */
 std::vector<size_t> CodeCompletionCore::getFollowingTokens(const antlr4::atn::Transition* transition
-) const {
+) {
   std::vector<size_t> result;
   std::vector<antlr4::atn::ATNState*> pipeline = {transition->target};
 
@@ -302,7 +302,7 @@ std::vector<size_t> CodeCompletionCore::getFollowingTokens(const antlr4::atn::Tr
       if (outgoing->getTransitionType() == antlr4::atn::TransitionType::ATOM) {
         if (!outgoing->isEpsilon()) {
           const auto list = outgoing->label();
-          if (list.size() == 1 && !ignoredTokens.contains(list.get(0))) {
+          if (list.size() == 1) {
             result.push_back(list.get(0));
             pipeline.push_back(outgoing->target);
           }
@@ -501,6 +501,7 @@ CodeCompletionCore::RuleEndStatus CodeCompletionCore::processRule(  // NOLINT
     antlr4::atn::RuleStopState* stop = atn->ruleToStopState[startState->ruleIndex];
     setsPerState[startState->stateNumber] = determineFollowSets(startState, stop);
   }
+
   const FollowSetsHolder& followSets = setsPerState[startState->stateNumber];
 
   // Get the token index where our rule starts from our (possibly filtered)

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.cpp
@@ -131,6 +131,13 @@ CandidatesCollection CodeCompletionCore::collectCandidates(
 
   processRule(atn->ruleToStartState[startRule], 0, callStack, 0, 0, candidates.isCancelled);
 
+  for (auto& [_, following] : candidates.tokens) {
+    auto removed = std::ranges::remove_if(following, [&](size_t token) {
+      return ignoredTokens.contains(token);
+    });
+    following.erase(std::begin(removed), std::end(removed));
+  }
+
   if (debugOptions.showResult) {
     if (candidates.isCancelled) {
       std::cout << "*** TIMED OUT ***\n";

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
@@ -258,6 +258,8 @@ private:
   );
 
   void printRuleState(RuleWithStartTokenList const& stack);
+
+  void printOverallResults();
 };
 
 }  // namespace c3

--- a/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
+++ b/ports/cpp/source/antlr4-c3/CodeCompletionCore.hpp
@@ -225,7 +225,7 @@ private:
 
   bool translateToRuleIndex(size_t index, RuleWithStartTokenList const& ruleWithStartTokenList);
 
-  std::vector<size_t> getFollowingTokens(const antlr4::atn::Transition* transition) const;
+  static std::vector<size_t> getFollowingTokens(const antlr4::atn::Transition* transition);
 
   FollowSetsHolder determineFollowSets(antlr4::atn::ATNState* start, antlr4::atn::ATNState* stop);
 

--- a/ports/cpp/test/expr/ExprTest.cpp
+++ b/ports/cpp/test/expr/ExprTest.cpp
@@ -98,8 +98,8 @@ TEST(SimpleExpressionParser, TypicalSetup) {
     auto candidates = completion.collectCandidates(0);
     EXPECT_THAT(Keys(candidates.tokens), UnorderedElementsAre(ExprLexer::VAR, ExprLexer::LET));
 
-    EXPECT_THAT(candidates.tokens[ExprLexer::VAR], ElementsAre(ExprLexer::ID, ExprLexer::EQUAL));
-    EXPECT_THAT(candidates.tokens[ExprLexer::LET], ElementsAre(ExprLexer::ID, ExprLexer::EQUAL));
+    EXPECT_THAT(candidates.tokens[ExprLexer::VAR], ElementsAre());
+    EXPECT_THAT(candidates.tokens[ExprLexer::LET], ElementsAre());
   }
   {
     // 2) On the variable name ('c').

--- a/ports/cpp/test/expr/ExprTest.cpp
+++ b/ports/cpp/test/expr/ExprTest.cpp
@@ -98,9 +98,8 @@ TEST(SimpleExpressionParser, TypicalSetup) {
     auto candidates = completion.collectCandidates(0);
     EXPECT_THAT(Keys(candidates.tokens), UnorderedElementsAre(ExprLexer::VAR, ExprLexer::LET));
 
-    // NOTE: Behaviour differs from TypeScript version
-    EXPECT_THAT(candidates.tokens[ExprLexer::VAR], UnorderedElementsAre());
-    EXPECT_THAT(candidates.tokens[ExprLexer::LET], UnorderedElementsAre());
+    EXPECT_THAT(candidates.tokens[ExprLexer::VAR], ElementsAre(ExprLexer::ID, ExprLexer::EQUAL));
+    EXPECT_THAT(candidates.tokens[ExprLexer::LET], ElementsAre(ExprLexer::ID, ExprLexer::EQUAL));
   }
   {
     // 2) On the variable name ('c').

--- a/ports/cpp/test/whitebox/WhiteboxTest.cpp
+++ b/ports/cpp/test/whitebox/WhiteboxTest.cpp
@@ -82,7 +82,7 @@ TEST(WhiteboxGrammarTests, CaretAtOneOfMultiplePossibleStates) {
     auto candidates = completion.collectCandidates(2, {ctx});
 
     EXPECT_THAT(Keys(candidates.tokens), UnorderedElementsAre(WhiteboxLexer::DOLOR));
-    EXPECT_THAT(candidates.tokens[WhiteboxLexer::DOLOR], UnorderedElementsAre());
+    EXPECT_THAT(candidates.tokens[WhiteboxLexer::DOLOR], ElementsAre());
   }
 }
 
@@ -95,7 +95,7 @@ TEST(WhiteboxGrammarTests, CaretAtOneOfMultiplePossibleStatesWithCommonFollowLis
   auto candidates = completion.collectCandidates(2, {ctx});
 
   EXPECT_THAT(Keys(candidates.tokens), UnorderedElementsAre(WhiteboxLexer::DOLOR));
-  EXPECT_THAT(candidates.tokens[WhiteboxLexer::DOLOR], UnorderedElementsAre(WhiteboxLexer::SIT));
+  EXPECT_THAT(candidates.tokens[WhiteboxLexer::DOLOR], ElementsAre(WhiteboxLexer::SIT));
 }
 
 }  // namespace c3::test


### PR DESCRIPTION
There is a problem explained at https://github.com/mike-lischke/antlr4-c3/issues/136#issuecomment-2268664819 because of cache dependency on `ignoredTokens` value. I just removed the token filter in `getFollowingTokens`. This logic originally was added in "Initial commit" 7 years ago, so motivation is unclear. On the one hand, tests were not changed, so the behavior with which all are agreed is the same. On the other hand, now we can get some elements of `ignoredTokens` in `followSet` from `candidates`. It can be fixed by simply adding a check after `followSet` was received either from the cache or computation.

@mike-lischke, there are two questions:

1. Do we want to filter tokens in follow set?

If yes, then I'll do changes and this test case will be OK:

```
core = CodeCompletionCore(X)
follow = core.collectCandidates(Y).tokens[Z] 
assert follow == [A, B, C]

core = CodeCompletionCore(X)
core.ignoredTokens.add(B)
follow = core.collectCandidates(Y).tokens[Z] 
assert follow == [A, C] // on 5eaad7b it returns [A, B, C]
```

2. Do we want to propagate this change to all ports (TypeScript, Java)?