### PR TITLE
Replace isPrecedenceRule with isLeftRecursive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.4.1",
             "license": "MIT",
             "dependencies": {
-                "antlr4ng": "3.0.7"
+                "antlr4ng": "3.0.14"
             },
             "devDependencies": {
                 "@types/jest": "29.5.12",
@@ -2461,9 +2461,9 @@
             }
         },
         "node_modules/antlr4ng": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/antlr4ng/-/antlr4ng-3.0.7.tgz",
-            "integrity": "sha512-e9VzrS6fErCUTmkZX2eKEMCsmYY87gVhmHkzmOXtUDgvwGhivUvtiHqlOByDx4Nd1PIQ0lMlhflOWEz6cGXqKA==",
+            "version": "3.0.14",
+            "resolved": "https://registry.npmjs.org/antlr4ng/-/antlr4ng-3.0.14.tgz",
+            "integrity": "sha512-EVEn3B3zpxgbq/731dhwMYCls9e8mAudBvo479hoXbX/yTL24Do1HNZEU+v1U6GayIFrow5EcHMdyXqqRXTtBw==",
             "license": "BSD-3-Clause",
             "peerDependencies": {
                 "antlr4ng-cli": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "typescript": "5.5.2"
     },
     "dependencies": {
-        "antlr4ng": "3.0.7"
+        "antlr4ng": "3.0.14"
     },
     "exports": {
         "types": "./lib/index.d.ts",

--- a/src/CodeCompletionCore.ts
+++ b/src/CodeCompletionCore.ts
@@ -582,7 +582,7 @@ export class CodeCompletionCore {
             }
         }
 
-        if (startState.isPrecedenceRule) {
+        if (startState.isLeftRecursiveRule) {
             this.precedenceStack.push(precedence);
         }
 
@@ -733,7 +733,7 @@ export class CodeCompletionCore {
         }
 
         callStack.pop();
-        if (startState.isPrecedenceRule) {
+        if (startState.isLeftRecursiveRule) {
             this.precedenceStack.pop();
         }
 


### PR DESCRIPTION
As discussed in https://github.com/mike-lischke/antlr4-c3/issues/165 this PR:

- Replaces `isPrecedenceRule` with `isLeftRecursiveRule`
- Bumps `antlr4ng` dependency to the latest patch

Ran the tests and they are all green 🟢 