### PR TITLE
#168 Add Java port Whitebox and Expr tests

### DIFF
--- a/ports/java/.devcontainer/devcontainer.json
+++ b/ports/java/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "image": "maven:3.9.9-eclipse-temurin-23",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "redhat.java",
+                "vscjava.vscode-java-debug",
+                "vscjava.vscode-java-test",
+                "vscjava.vscode-maven",
+                "vscjava.vscode-java-dependency",
+                "VisualStudioExptTeam.vscodeintellicode"
+            ]
+        }
+    }
+}

--- a/ports/java/.vscode/settings.json
+++ b/ports/java/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/ports/java/pom.xml
+++ b/ports/java/pom.xml
@@ -52,7 +52,7 @@
   </distributionManagement>
 
   <properties>
-    <junit.version>4.13.1</junit.version>
+    <junit.version>5.12.1</junit.version>
     <antlr4.version>4.7</antlr4.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -62,8 +62,8 @@
   <dependencies>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>

--- a/ports/java/src/main/java/com/vmware/antlr4c3/CodeCompletionCore.java
+++ b/ports/java/src/main/java/com/vmware/antlr4c3/CodeCompletionCore.java
@@ -7,300 +7,211 @@
  */
 package com.vmware.antlr4c3;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.antlr.v4.runtime.Parser;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.TokenStream;
-import org.antlr.v4.runtime.Vocabulary;
-import org.antlr.v4.runtime.atn.ATN;
-import org.antlr.v4.runtime.atn.ATNState;
-import org.antlr.v4.runtime.atn.PredicateTransition;
-import org.antlr.v4.runtime.atn.RuleStopState;
-import org.antlr.v4.runtime.atn.RuleTransition;
-import org.antlr.v4.runtime.atn.Transition;
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.misc.IntervalSet;
 
-/**
- * Port of antlr-c3 javascript library to java
- * <p>
- * The c3 engine is able to provide code completion candidates useful for
- * editors with ANTLR generated parsers, independent of the actual
- * language/grammar used for the generation.
- */
+import java.util.*;
+import java.util.stream.Collectors;
+
 public class CodeCompletionCore {
-    
-    public final static Logger logger = Logger.getLogger(CodeCompletionCore.class.getName());
+    private static Map<String, Map<Integer, FollowSetsHolder>> followSetsByATN = new HashMap<>();
 
-    /**
-     * JDO returning information about matching tokens and rules
-     */
-    public static class CandidatesCollection {
-        /**
-         * Collection of Token ID candidates, each with a follow-on List of
-         * subsequent tokens
-         */
-        public Map<Integer, List<Integer>> tokens = new HashMap<>();
-        /**
-         * Collection of Rule candidates, each with the callstack of rules to
-         * reach the candidate
-         */
-        public Map<Integer, List<Integer>> rules = new HashMap<>();
-        /**
-         * Collection of matched Preferred Rules each with their start and end
-         * offsets
-         */
-        public Map<Integer, List<Integer>> rulePositions = new HashMap<>();
+    private static String[] atnStateTypeMap = {
+            "invalid",
+            "basic",
+            "rule start",
+            "block start",
+            "plus block start",
+            "star block start",
+            "token start",
+            "rule stop",
+            "block end",
+            "star loop back",
+            "star loop entry",
+            "plus loop back",
+            "loop end"
+    };
 
-        @Override
-        public String toString() {
-            return "CandidatesCollection{" + "tokens=" + tokens + ", rules=" + rules + ", ruleStrings=" + rulePositions + '}';
-        }
-    }
-    
-    public static class FollowSetWithPath {
-        public IntervalSet intervals;
-        public List<Integer> path;
-        public List<Integer> following;
-    }
-    
-    public static class FollowSetsHolder {
-        public List<FollowSetWithPath> sets;
-        public IntervalSet combined;
-    }
+    // Debugging options
+    public boolean showResult = false;
+    public boolean showDebugOutput = false;
+    public boolean debugOutputWithTransitions = false;
+    public boolean showRuleStack = false;
 
-    public static class PipelineEntry {
+    public Set<Integer> ignoredTokens = new HashSet<>();
+    public Set<Integer> preferredRules = new HashSet<>();
+    public boolean translateRulesTopDown = false;
 
-        public PipelineEntry(ATNState state, Integer tokenIndex) {
-            this.state = state;
-            this.tokenIndex = tokenIndex;
-        }
-        
-        ATNState state;
-        Integer tokenIndex;
-    }
-
-    private boolean showResult = true;
-    private boolean showDebugOutput = true;
-    private boolean debugOutputWithTransitions = true;
-    private boolean showRuleStack = true;
-    
-    private Set<Integer> ignoredTokens = new HashSet<>();
-    private Set<Integer> preferredRules = new HashSet<>();
-    
     private Parser parser;
     private ATN atn;
     private Vocabulary vocabulary;
     private String[] ruleNames;
     private List<Token> tokens;
+    private List<Integer> precedenceStack;
 
     private int tokenStartIndex = 0;
     private int statesProcessed = 0;
-    
-    // A mapping of rule index to token stream position to end token positions.
-    // A rule which has been visited before with the same input position will always produce the same output positions.
-    private final Map<Integer, Map<Integer, Set<Integer>>> shortcutMap = new HashMap<>();
-    private final CandidatesCollection candidates = new CandidatesCollection(); // The collected candidates (rules and tokens).
 
-    private final static Map<String, Map<Integer, FollowSetsHolder>> followSetsByATN = new HashMap<>();
-    
-    public CodeCompletionCore(Parser parser, Set<Integer> preferredRules, Set<Integer> ignoredTokens) {
+    private Map<Integer, Map<Integer, Set<Integer>>> shortcutMap = new HashMap<>();
+    private CandidatesCollection candidates = new CandidatesCollection();
+
+    public CodeCompletionCore(Parser parser) {
         this.parser = parser;
         this.atn = parser.getATN();
         this.vocabulary = parser.getVocabulary();
         this.ruleNames = parser.getRuleNames();
-        if (preferredRules != null) {
-            this.preferredRules = preferredRules;
-        }
-        if (ignoredTokens != null) {
-            this.ignoredTokens = ignoredTokens;
-        }
     }
 
-    public Set<Integer> getPreferredRules() {
-        return Collections.unmodifiableSet(preferredRules);
-    }
-    
-    public void setPreferredRules(Set<Integer> preferredRules) {
-        this.preferredRules = new HashSet<>(preferredRules);
-    }
-
-    /**
-     * This is the main entry point. The caret token index specifies the token stream index for the token which currently
-     * covers the caret (or any other position you want to get code completion candidates for).
-     * Optionally you can pass in a parser rule context which limits the ATN walk to only that or called rules. This can significantly
-     * speed up the retrieval process but might miss some candidates (if they are outside of the given context).
-     */
     public CandidatesCollection collectCandidates(int caretTokenIndex, ParserRuleContext context) {
-        this.shortcutMap.clear();
-        this.candidates.rules.clear();
-        this.candidates.tokens.clear();
-        this.statesProcessed = 0;
+        shortcutMap.clear();
+        candidates.rules.clear();
+        candidates.tokens.clear();
+        statesProcessed = 0;
+        precedenceStack = new ArrayList<>();
 
-        this.tokenStartIndex = context != null ? context.start.getTokenIndex() : 0;
-        TokenStream tokenStream  = this.parser.getInputStream();
+        this.tokenStartIndex = context != null && context.start != null ? context.start.getTokenIndex() : 0;
+        TokenStream tokenStream = parser.getTokenStream();
 
-        int currentIndex = tokenStream.index();
-        tokenStream.seek(this.tokenStartIndex);
-        this.tokens = new LinkedList<>();
-        int offset = 1;
+        tokens = new ArrayList<>();
+        int offset = tokenStartIndex;
         while (true) {
-            Token token = tokenStream.LT(offset++);
-            this.tokens.add(token);
-            if (token.getTokenIndex() >= caretTokenIndex || token.getType() == Token.EOF) {
+            Token token = tokenStream.get(offset++);
+            if (token == null) {
+                break;
+            }
+            if (token.getChannel() == Token.DEFAULT_CHANNEL) {
+                tokens.add(token);
+
+                if (token.getTokenIndex() >= caretTokenIndex || token.getType() == Token.EOF) {
+                    break;
+                }
+            }
+
+            if (token.getType() == Token.EOF) {
                 break;
             }
         }
-        tokenStream.seek(currentIndex);
 
-        LinkedList<Integer> callStack = new LinkedList<>();
+        List<RuleWithStartToken> callStack = new ArrayList<>();
         int startRule = context != null ? context.getRuleIndex() : 0;
-        this.processRule(this.atn.ruleToStartState[startRule], 0, callStack, "\n");
+        processRule((RuleStartState) atn.ruleToStartState[startRule], 0, callStack, 0, 0);
 
-        tokenStream.seek(currentIndex);
-
-        // now post-process the rule candidates and find the last occurrences
-        // of each preferred rule and extract its start and end in the input stream
-        for (int ruleId : preferredRules) {
-            final Map<Integer, Set<Integer>> shortcut = shortcutMap.get(ruleId);
-            if (shortcut == null || shortcut.isEmpty()) {
-                continue;
-            }
-            // select the right-most occurrence
-            final int startToken = Collections.max(shortcut.keySet());
-            final Set<Integer> endSet = shortcut.get(startToken);
-            final int endToken;
-            if (endSet.isEmpty()) {
-                endToken = tokens.size() - 1;
-            } else {
-                endToken = Collections.max(shortcut.get(startToken));
-            }
-            final int startOffset = tokens.get(startToken).getStartIndex();
-            final int endOffset;
-            if (tokens.get(endToken).getType() == Token.EOF) {
-                // if last token is EOF, include trailing whitespace
-                endOffset = tokens.get(endToken).getStartIndex();
-            } else {
-                // if last token is not EOF, limit to matching tokens which excludes trailing whitespace
-                endOffset = tokens.get(endToken - 1).getStopIndex() + 1;
+        if (showResult) {
+            System.out.println("States processed: " + statesProcessed);
+            System.out.println("\n\nCollected rules:\n");
+            for (Map.Entry<Integer, CandidateRule> entry : candidates.rules.entrySet()) {
+                String path = entry.getValue().ruleList.stream()
+                        .map(ruleIndex -> ruleNames[ruleIndex])
+                        .collect(Collectors.joining(" "));
+                System.out.println(ruleNames[entry.getKey()] + ", path: " + path);
             }
 
-            final List<Integer> ruleStartStop = Arrays.asList(startOffset, endOffset);
-            candidates.rulePositions.put(ruleId, ruleStartStop);
+            Set<String> sortedTokens = new TreeSet<>();
+            for (Map.Entry<Integer, List<Integer>> entry : candidates.tokens.entrySet()) {
+                String value = vocabulary.getDisplayName(entry.getKey());
+                for (int following : entry.getValue()) {
+                    value += " " + vocabulary.getDisplayName(following);
+                }
+                sortedTokens.add(value);
+            }
+
+            System.out.println("\n\nCollected tokens:\n");
+            for (String symbol : sortedTokens) {
+                System.out.println(symbol);
+            }
+            System.out.println("\n\n");
         }
 
-        if (this.showResult && logger.isLoggable(Level.FINE)) {
-            StringBuilder logMessage = new StringBuilder();
-            
-            logMessage.append("States processed: ").append(this.statesProcessed).append("\n");
-
-            logMessage.append("Collected rules:\n");
-
-            for (Map.Entry<Integer, List<Integer>> entry : this.candidates.rules.entrySet()) {
-
-                logMessage.append("  ").append(entry.getKey()).append(", path: ");
-                for (Integer token : entry.getValue()) {
-                    logMessage.append(this.ruleNames[token]).append(" ");
-                }
-                logMessage.append("\n");
-            }
-            
-            logMessage.append("Collected Tokens:\n");
-            for (Map.Entry<Integer, List<Integer>> entry : this.candidates.tokens.entrySet()) {
-                logMessage.append("  ").append(this.vocabulary.getDisplayName(entry.getKey()));
-                for (Integer following : entry.getValue()) {
-                    logMessage.append(" ").append(this.vocabulary.getDisplayName(following));
-                }
-                logMessage.append("\n");
-            }
-            logger.log(Level.FINE, logMessage.toString());
-        }
-
-        return this.candidates;
+        return candidates;
     }
-    
 
-    /**
-     * Check if the predicate associated with the given transition evaluates to true.
-     */
     private boolean checkPredicate(PredicateTransition transition) {
-        return transition.getPredicate().eval(this.parser, ParserRuleContext.EMPTY);
+        return transition.getPredicate().eval(parser, ParserRuleContext.EMPTY);
     }
 
-    /**
-     * Walks the rule chain upwards to see if that matches any of the preferred rules.
-     * If found, that rule is added to the collection candidates and true is returned.
-     */
-    private boolean translateToRuleIndex(List<Integer> ruleStack) {
-        if (this.preferredRules.isEmpty())
+    private boolean translateStackToRuleIndex(List<RuleWithStartToken> ruleWithStartTokenList) {
+        if (preferredRules.isEmpty()) {
             return false;
+        }
 
-        // Loop over the rule stack from highest to lowest rule level. This way we properly handle the higher rule
-        // if it contains a lower one that is also a preferred rule.
-        for (int i = 0; i < ruleStack.size(); ++i) {
-            if (this.preferredRules.contains(ruleStack.get(i))) {
-                // Add the rule to our candidates list along with the current rule path,
-                // but only if there isn't already an entry like that.
-                List<Integer> path = new LinkedList<>(ruleStack.subList(0, i));
-                boolean addNew = true;
-                for (Map.Entry<Integer, List<Integer>> entry : this.candidates.rules.entrySet()) {
-                    if (!entry.getKey().equals(ruleStack.get(i)) || entry.getValue().size() != path.size()) {
-                        continue;
-                    }
-                    // Found an entry for this rule. Same path? If so don't add a new (duplicate) entry.
-                    if (path.equals(entry.getValue())) {
-                        addNew = false;
-                        break;
-                    }
+        if (translateRulesTopDown) {
+            for (int i = ruleWithStartTokenList.size() - 1; i >= 0; i--) {
+                if (translateToRuleIndex(i, ruleWithStartTokenList)) {
+                    return true;
                 }
-
-                if (addNew) {
-                    this.candidates.rules.put(ruleStack.get(i), path);
-                    if (showDebugOutput && logger.isLoggable(Level.FINE)) {
-                        logger.fine("=====> collected: " + this.ruleNames[i]);
-                    }
+            }
+        } else {
+            for (int i = 0; i < ruleWithStartTokenList.size(); i++) {
+                if (translateToRuleIndex(i, ruleWithStartTokenList)) {
+                    return true;
                 }
-                return true;
             }
         }
 
         return false;
     }
-    
 
-    /**
-     * This method follows the given transition and collects all symbols within the same rule that directly follow it
-     * without intermediate transitions to other rules and only if there is a single symbol for a transition.
-     */
-    private List<Integer> getFollowingTokens(Transition initialTransition) {
-        LinkedList<Integer> result = new LinkedList<>();
-        LinkedList<ATNState> seen = new LinkedList<>(); // unused but in orig
-        LinkedList<ATNState> pipeline = new LinkedList<>();
-        pipeline.add(initialTransition.target);
+    private boolean translateToRuleIndex(int i, List<RuleWithStartToken> ruleWithStartTokenList) {
+        RuleWithStartToken ruleWithStartToken = ruleWithStartTokenList.get(i);
+        int ruleIndex = ruleWithStartToken.ruleIndex;
+        if (preferredRules.contains(ruleIndex)) {
+            int startTokenIndex = ruleWithStartToken.startTokenIndex;
+            List<Integer> path = ruleWithStartTokenList.subList(0, i).stream()
+                    .map(r -> r.ruleIndex)
+                    .collect(Collectors.toList());
+
+            boolean addNew = true;
+            for (Map.Entry<Integer, CandidateRule> entry : candidates.rules.entrySet()) {
+                if (!entry.getKey().equals(ruleIndex) || entry.getValue().ruleList.size() != path.size()) {
+                    continue;
+                }
+
+                boolean samePath = true;
+                for (int j = 0; j < path.size(); j++) {
+                    if (!path.get(j).equals(entry.getValue().ruleList.get(j))) {
+                        samePath = false;
+                        break;
+                    }
+                }
+
+                if (samePath) {
+                    addNew = false;
+                    break;
+                }
+            }
+
+            if (addNew) {
+                candidates.rules.put(ruleIndex, new CandidateRule(startTokenIndex, path));
+                if (showDebugOutput) {
+                    System.out.println("=====> collected: " + ruleNames[ruleIndex]);
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private List<Integer> getFollowingTokens(Transition transition) {
+        List<Integer> result = new ArrayList<>();
+        Stack<ATNState> pipeline = new Stack<>();
+        pipeline.push(transition.target);
 
         while (!pipeline.isEmpty()) {
-            ATNState state = pipeline.removeLast();
+            ATNState state = pipeline.pop();
 
-            for (Transition transition: state.getTransitions()) {
-                if (transition.getSerializationType() == Transition.ATOM) {
-                    if (!transition.isEpsilon()) {
-                        List<Integer> list = transition.label().toList();
-                        if (list.size() == 1 && !this.ignoredTokens.contains(list.get(0))) {
-                            result.addLast(list.get(0));
-                            pipeline.addLast(transition.target);
+            for (Transition outgoing : state.getTransitions()) {
+                if (outgoing.getSerializationType() == Transition.ATOM) {
+                    if (!outgoing.isEpsilon()) {
+                        IntervalSet label = outgoing.label();
+                        if (label != null && label.size() == 1 && !ignoredTokens.contains(label.getMinElement())) {
+                            result.add(label.getMinElement());
+                            pipeline.push(outgoing.target);
                         }
                     } else {
-                        pipeline.addLast(transition.target);
+                        pipeline.push(outgoing.target);
                     }
                 }
             }
@@ -309,287 +220,268 @@ public class CodeCompletionCore {
         return result;
     }
 
-    /**
-     * Entry point for the recursive follow set collection function.
-     */
-    private LinkedList<FollowSetWithPath> determineFollowSets(ATNState start, ATNState stop){
-        LinkedList<FollowSetWithPath> result = new LinkedList<>();
-        Set<ATNState> seen = new HashSet<>();
-        LinkedList<Integer> ruleStack = new LinkedList<>();
+    private FollowSetsHolder determineFollowSets(ATNState start, ATNState stop) {
+        List<FollowSetWithPath> sets = new ArrayList<>();
+        Stack<ATNState> stateStack = new Stack<>();
+        Stack<Integer> ruleStack = new Stack<>();
+        boolean isExhaustive = collectFollowSets(start, stop, sets, stateStack, ruleStack);
 
-        this.collectFollowSets(start, stop, result, seen, ruleStack);
-
-        return result;
-    }
-
-    /**
-     * Collects possible tokens which could be matched following the given ATN state. This is essentially the same
-     * algorithm as used in the LL1Analyzer class, but here we consider predicates also and use no parser rule context.
-     */
-    private void collectFollowSets(ATNState s, ATNState stopState, LinkedList<FollowSetWithPath> followSets,
-            Set<ATNState> seen, LinkedList<Integer> ruleStack) {
-
-        if (seen.contains(s))
-            return;
-
-        seen.add(s);
-
-        if (s.equals(stopState) || s.getStateType() == ATNState.RULE_STOP) {
-            FollowSetWithPath set = new FollowSetWithPath();
-            set.intervals = IntervalSet.of(Token.EPSILON);
-            set.path = new LinkedList<Integer>(ruleStack);
-            set.following = new LinkedList<Integer>();
-            followSets.addLast(set);
-            return;
+        IntervalSet combined = new IntervalSet();
+        for (FollowSetWithPath set : sets) {
+            combined.addAll(set.intervals);
         }
 
+        return new FollowSetsHolder(sets, combined, isExhaustive);
+    }
+
+    private boolean collectFollowSets(ATNState s, ATNState stopState, List<FollowSetWithPath> followSets,
+            Stack<ATNState> stateStack, Stack<Integer> ruleStack) {
+        if (stateStack.contains(s)) {
+            return true;
+        }
+        stateStack.push(s);
+
+        if (s == stopState || s.getStateType() == ATNState.RULE_STOP) {
+            stateStack.pop();
+            return false;
+        }
+
+        boolean isExhaustive = true;
         for (Transition transition : s.getTransitions()) {
             if (transition.getSerializationType() == Transition.RULE) {
                 RuleTransition ruleTransition = (RuleTransition) transition;
-                if (ruleStack.indexOf(ruleTransition.target.ruleIndex) != -1) {
+                if (ruleStack.contains(ruleTransition.target.ruleIndex)) {
                     continue;
                 }
-                ruleStack.addLast(ruleTransition.target.ruleIndex);
-                this.collectFollowSets(transition.target, stopState, followSets, seen, ruleStack);
-                ruleStack.removeLast();
+
+                ruleStack.push(ruleTransition.target.ruleIndex);
+                boolean ruleFollowSetsIsExhaustive = collectFollowSets(
+                        transition.target, stopState, followSets, stateStack, ruleStack);
+                ruleStack.pop();
+
+                if (!ruleFollowSetsIsExhaustive) {
+                    boolean nextStateFollowSetsIsExhaustive = collectFollowSets(
+                            ruleTransition.followState, stopState, followSets, stateStack, ruleStack);
+                    isExhaustive &= nextStateFollowSetsIsExhaustive;
+                }
 
             } else if (transition.getSerializationType() == Transition.PREDICATE) {
-                if (this.checkPredicate((PredicateTransition) transition)) {
-                    this.collectFollowSets(transition.target, stopState, followSets, seen, ruleStack);
+                if (checkPredicate((PredicateTransition) transition)) {
+                    boolean nextStateFollowSetsIsExhaustive = collectFollowSets(
+                            transition.target, stopState, followSets, stateStack, ruleStack);
+                    isExhaustive &= nextStateFollowSetsIsExhaustive;
                 }
             } else if (transition.isEpsilon()) {
-                this.collectFollowSets(transition.target, stopState, followSets, seen, ruleStack);
+                boolean nextStateFollowSetsIsExhaustive = collectFollowSets(
+                        transition.target, stopState, followSets, stateStack, ruleStack);
+                isExhaustive &= nextStateFollowSetsIsExhaustive;
             } else if (transition.getSerializationType() == Transition.WILDCARD) {
                 FollowSetWithPath set = new FollowSetWithPath();
-                set.intervals = IntervalSet.of(Token.MIN_USER_TOKEN_TYPE, this.atn.maxTokenType);
-                set.path = new LinkedList<Integer>(ruleStack);
-                set.following = new LinkedList<Integer>();
-                followSets.addLast(set);
+                set.intervals = IntervalSet.of(Token.MIN_USER_TOKEN_TYPE, atn.maxTokenType);
+                set.path = new ArrayList<>(ruleStack);
+                followSets.add(set);
             } else {
                 IntervalSet label = transition.label();
-                if (label != null && label.size() > 0) {
+                if (label != null && label.size() != 0) {
                     if (transition.getSerializationType() == Transition.NOT_SET) {
-                        label = label.complement(IntervalSet.of(Token.MIN_USER_TOKEN_TYPE, this.atn.maxTokenType));
+                        label = label.complement(Token.MIN_USER_TOKEN_TYPE, atn.maxTokenType);
                     }
                     FollowSetWithPath set = new FollowSetWithPath();
                     set.intervals = label;
-                    set.path = new LinkedList<Integer>(ruleStack);
-                    set.following = this.getFollowingTokens(transition);
-                    followSets.addLast(set);
+                    set.path = new ArrayList<>(ruleStack);
+                    set.following = getFollowingTokens(transition);
+                    followSets.add(set);
                 }
             }
         }
+        stateStack.pop();
+
+        return isExhaustive;
     }
-    
-    /**
-     * Walks the ATN for a single rule only. It returns the token stream position for each path that could be matched in this rule.
-     * The result can be empty in case we hit only non-epsilon transitions that didn't match the current input or if we
-     * hit the caret position.
-     */
-    private Set<Integer> processRule(ATNState startState, int tokenIndex, LinkedList<Integer> callStack, String indentation) {
 
-        // Start with rule specific handling before going into the ATN walk.
+    private Set<Integer> processRule(RuleStartState startState, int tokenListIndex,
+            List<RuleWithStartToken> callStack, int precedence, int indentation) {
+        Map<Integer, Set<Integer>> positionMap = shortcutMap.computeIfAbsent(
+                startState.ruleIndex, k -> new HashMap<>());
 
-        // Check first if we've taken this path with the same input before.
-        Map<Integer,Set<Integer>> positionMap = this.shortcutMap.get(startState.ruleIndex);
-        if (positionMap == null) {
-            positionMap = new HashMap<>();
-            this.shortcutMap.put(startState.ruleIndex, positionMap);
-        } else {
-            if (positionMap.containsKey(tokenIndex)) {
-                if (showDebugOutput) {
-                    logger.fine("=====> shortcut");
-                }
-                return positionMap.get(tokenIndex);
+        if (positionMap.containsKey(tokenListIndex)) {
+            if (showDebugOutput) {
+                System.out.println("=====> shortcut");
             }
+            return positionMap.get(tokenListIndex);
         }
 
         Set<Integer> result = new HashSet<>();
 
-        // For rule start states we determine and cache the follow set, which gives us 3 advantages:
-        // 1) We can quickly check if a symbol would be matched when we follow that rule. We can so check in advance
-        //    and can save us all the intermediate steps if there is no match.
-        // 2) We'll have all symbols that are collectable already together when we are at the caret when entering a rule.
-        // 3) We get this lookup for free with any 2nd or further visit of the same rule, which often happens
-        //    in non trivial grammars, especially with (recursive) expressions and of course when invoking code completion
-        //    multiple times.
-        Map<Integer, FollowSetsHolder> setsPerState = followSetsByATN.get(this.parser.getClass().getName());
-        if (setsPerState == null) {
-            setsPerState = new HashMap<>();
-            followSetsByATN.put(this.parser.getClass().getName(), setsPerState);
-        }
+        Map<Integer, FollowSetsHolder> setsPerState = followSetsByATN.computeIfAbsent(
+                parser.getClass().getName(), k -> new HashMap<>());
 
         FollowSetsHolder followSets = setsPerState.get(startState.stateNumber);
         if (followSets == null) {
-            followSets = new FollowSetsHolder();
+            RuleStopState stop = atn.ruleToStopState[startState.ruleIndex];
+            followSets = determineFollowSets(startState, stop);
             setsPerState.put(startState.stateNumber, followSets);
-            RuleStopState stop = this.atn.ruleToStopState[startState.ruleIndex];
-            followSets.sets = this.determineFollowSets(startState, stop);
-
-            // Sets are split by path to allow translating them to preferred rules. But for quick hit tests
-            // it is also useful to have a set with all symbols combined.
-            IntervalSet combined = new IntervalSet();
-            for (FollowSetWithPath set: followSets.sets) {
-                combined.addAll(set.intervals);
-            }
-            followSets.combined = combined;
         }
 
-        callStack.addLast(startState.ruleIndex);
-        int currentSymbol = this.tokens.get(tokenIndex).getType();
+        int startTokenIndex = tokens.get(tokenListIndex).getTokenIndex();
+        callStack.add(new RuleWithStartToken(startTokenIndex, startState.ruleIndex));
 
-        if (tokenIndex >= this.tokens.size() - 1) { // At caret?
-            if (this.preferredRules.contains(startState.ruleIndex)) {
-                // No need to go deeper when collecting entries and we reach a rule that we want to collect anyway.
-                this.translateToRuleIndex(callStack);
+        if (tokenListIndex >= tokens.size() - 1) {
+            if (preferredRules.contains(startState.ruleIndex)) {
+                translateStackToRuleIndex(callStack);
             } else {
-                // Convert all follow sets to either single symbols or their associated preferred rule and add
-                // the result to our candidates list.
-                for (FollowSetWithPath set: followSets.sets) {
-                    LinkedList<Integer> fullPath = new LinkedList<>(callStack);
-                    fullPath.addAll(set.path);
-                    if (!this.translateToRuleIndex(fullPath)) {
+                for (FollowSetWithPath set : followSets.sets) {
+                    List<RuleWithStartToken> fullPath = new ArrayList<>(callStack);
+                    List<RuleWithStartToken> followSetPath = set.path.stream()
+                            .map(ruleIndex -> new RuleWithStartToken(startTokenIndex, ruleIndex))
+                            .collect(Collectors.toList());
+                    fullPath.addAll(followSetPath);
+
+                    if (!translateStackToRuleIndex(fullPath)) {
                         for (int symbol : set.intervals.toList()) {
-                            if (!this.ignoredTokens.contains(symbol)) {
-                                if (showDebugOutput && logger.isLoggable(Level.FINE)) {
-                                    logger.fine("=====> collected: " + this.vocabulary.getDisplayName(symbol));
+                            if (!ignoredTokens.contains(symbol)) {
+                                if (showDebugOutput) {
+                                    System.out.println("=====> collected: " + vocabulary.getDisplayName(symbol));
                                 }
-                                if (!this.candidates.tokens.containsKey(symbol))
-                                    this.candidates.tokens.put(symbol, set.following); // Following is empty if there is more than one entry in the set.
-                                else {
-                                    // More than one following list for the same symbol.
-                                    if (!this.candidates.tokens.get(symbol).equals(set.following)) { // XXX js uses !=
-                                        this.candidates.tokens.put(symbol, new LinkedList<Integer>());
+                                if (!candidates.tokens.containsKey(symbol)) {
+                                    candidates.tokens.put(symbol, set.following);
+                                } else {
+                                    if (!candidates.tokens.get(symbol).equals(set.following)) {
+                                        candidates.tokens.put(symbol, Collections.emptyList());
                                     }
                                 }
-                            } else {
-                                logger.fine("====> collection: Ignoring token: " + symbol);
                             }
                         }
                     }
                 }
             }
 
-            callStack.removeLast();
-            return result;
+            if (!followSets.isExhaustive) {
+                result.add(tokenListIndex);
+            }
 
+            callStack.remove(callStack.size() - 1);
+            return result;
         } else {
-            // Process the rule if we either could pass it without consuming anything (epsilon transition)
-            // or if the current input symbol will be matched somewhere after this entry point.
-            // Otherwise stop here.
-            if (!followSets.combined.contains(Token.EPSILON) && !followSets.combined.contains(currentSymbol)) {
-                callStack.removeLast();
+            int currentSymbol = tokens.get(tokenListIndex).getType();
+            if (followSets.isExhaustive && !followSets.combined.contains(currentSymbol)) {
+                callStack.remove(callStack.size() - 1);
                 return result;
             }
         }
 
-        // The current state execution pipeline contains all yet-to-be-processed ATN states in this rule.
-        // For each such state we store the token index + a list of rules that lead to it.
-        LinkedList<PipelineEntry> statePipeline = new LinkedList<>();
-        PipelineEntry currentEntry;
+        if (startState.isLeftRecursiveRule) {
+            precedenceStack.add(precedence);
+        }
 
-        // Bootstrap the pipeline.
-        statePipeline.add(new PipelineEntry(startState, tokenIndex));
+        Stack<PipelineEntry> statePipeline = new Stack<>();
+        statePipeline.push(new PipelineEntry(startState, tokenListIndex));
 
         while (!statePipeline.isEmpty()) {
-            currentEntry = statePipeline.removeLast();
-            ++this.statesProcessed;
+            PipelineEntry currentEntry = statePipeline.pop();
+            statesProcessed++;
 
-            currentSymbol = this.tokens.get(currentEntry.tokenIndex).getType();
+            int currentSymbol = tokens.get(currentEntry.tokenListIndex).getType();
+            boolean atCaret = currentEntry.tokenListIndex >= tokens.size() - 1;
 
-            boolean atCaret = currentEntry.tokenIndex >= this.tokens.size() - 1;
-            if (logger.isLoggable(Level.FINE)) {
-                printDescription(indentation, currentEntry.state, this.generateBaseDescription(currentEntry.state), currentEntry.tokenIndex);
-                if (this.showRuleStack) {
+            if (showDebugOutput) {
+                printDescription(indentation, currentEntry.state,
+                        generateBaseDescription(currentEntry.state), currentEntry.tokenListIndex);
+                if (showRuleStack) {
                     printRuleState(callStack);
                 }
             }
 
-            switch (currentEntry.state.getStateType()) {
-                case ATNState.RULE_START: // Happens only for the first state in this rule, not subrules.
-                    indentation += "  ";
-                    break;
-
-                case ATNState.RULE_STOP: {
-                    // Record the token index we are at, to report it to the caller.
-                    result.add(currentEntry.tokenIndex);
-                    continue;
-                }
-
-                default:
-                    break;
+            if (currentEntry.state.getStateType() == ATNState.RULE_STOP) {
+                result.add(currentEntry.tokenListIndex);
+                continue;
             }
 
-            Transition[] transitions = currentEntry.state.getTransitions();
-            for (Transition transition : transitions) {
+            for (Transition transition : currentEntry.state.getTransitions()) {
                 switch (transition.getSerializationType()) {
                     case Transition.RULE: {
-                        Set<Integer> endStatus = this.processRule(transition.target, currentEntry.tokenIndex, callStack, indentation);
-                        for (Integer position : endStatus) {
-                            statePipeline.addLast(new PipelineEntry(((RuleTransition) transition).followState, position));
+                        RuleTransition ruleTransition = (RuleTransition) transition;
+                        Set<Integer> endStatus = processRule((RuleStartState) transition.target,
+                                currentEntry.tokenListIndex, callStack, ruleTransition.precedence, indentation + 1);
+                        for (int position : endStatus) {
+                            statePipeline.push(new PipelineEntry(ruleTransition.followState, position));
                         }
                         break;
                     }
 
                     case Transition.PREDICATE: {
-                        if (this.checkPredicate((PredicateTransition)transition)) {
-                            statePipeline.addLast(new PipelineEntry(transition.target, currentEntry.tokenIndex));
+                        if (checkPredicate((PredicateTransition) transition)) {
+                            statePipeline.push(new PipelineEntry(transition.target, currentEntry.tokenListIndex));
+                        }
+                        break;
+                    }
+
+                    case Transition.PRECEDENCE: {
+                        PrecedencePredicateTransition predTransition = (PrecedencePredicateTransition) transition;
+                        if (predTransition.precedence >= precedenceStack.get(precedenceStack.size() - 1)) {
+                            statePipeline.push(new PipelineEntry(transition.target, currentEntry.tokenListIndex));
                         }
                         break;
                     }
 
                     case Transition.WILDCARD: {
                         if (atCaret) {
-                            if (!this.translateToRuleIndex(callStack)) {
-                                for (Integer token : IntervalSet.of(Token.MIN_USER_TOKEN_TYPE, this.atn.maxTokenType).toList()) {
-                                    if (!this.ignoredTokens.contains(token)) {
-                                        this.candidates.tokens.put(token, new LinkedList<Integer>());
+                            if (!translateStackToRuleIndex(callStack)) {
+                                for (int token : IntervalSet.of(Token.MIN_USER_TOKEN_TYPE, atn.maxTokenType).toList()) {
+                                    if (!ignoredTokens.contains(token)) {
+                                        candidates.tokens.put(token, Collections.emptyList());
                                     }
                                 }
                             }
                         } else {
-                            statePipeline.addLast(new PipelineEntry(transition.target, currentEntry.tokenIndex + 1));
+                            statePipeline.push(new PipelineEntry(transition.target, currentEntry.tokenListIndex + 1));
                         }
                         break;
                     }
 
                     default: {
                         if (transition.isEpsilon()) {
-                            // Jump over simple states with a single outgoing epsilon transition.
-                            statePipeline.addLast(new PipelineEntry(transition.target, currentEntry.tokenIndex));
+                            statePipeline.push(new PipelineEntry(transition.target, currentEntry.tokenListIndex));
                             continue;
                         }
 
                         IntervalSet set = transition.label();
-                        if (set != null && set.size() > 0) {
+                        if (set != null && set.size() != 0) {
                             if (transition.getSerializationType() == Transition.NOT_SET) {
-                                set = set.complement(IntervalSet.of(Token.MIN_USER_TOKEN_TYPE, this.atn.maxTokenType));
+                                set = set.complement(Token.MIN_USER_TOKEN_TYPE, atn.maxTokenType);
                             }
                             if (atCaret) {
-                                if (!this.translateToRuleIndex(callStack)) {
+                                if (!translateStackToRuleIndex(callStack)) {
                                     List<Integer> list = set.toList();
-                                    boolean addFollowing = list.size() == 1;
-                                    for (Integer symbol: list) {
-                                        if (!this.ignoredTokens.contains(symbol)) {
-                                            if (showDebugOutput && logger.isLoggable(Level.FINE)) {
-                                                logger.fine("=====> collected: " + this.vocabulary.getDisplayName(symbol));
+                                    boolean hasTokenSequence = list.size() == 1;
+                                    for (int symbol : list) {
+                                        if (!ignoredTokens.contains(symbol)) {
+                                            if (showDebugOutput) {
+                                                System.out.println("=====> collected: " +
+                                                        vocabulary.getDisplayName(symbol));
                                             }
-                                            if (addFollowing) {
-                                                this.candidates.tokens.put(symbol, this.getFollowingTokens(transition));
+
+                                            List<Integer> followingTokens = hasTokenSequence
+                                                    ? getFollowingTokens(transition)
+                                                    : Collections.emptyList();
+                                            if (!candidates.tokens.containsKey(symbol)) {
+                                                candidates.tokens.put(symbol, followingTokens);
                                             } else {
-                                                this.candidates.tokens.put(symbol, new LinkedList<>());
+                                                candidates.tokens.put(symbol,
+                                                        longestCommonPrefix(followingTokens,
+                                                                candidates.tokens.get(symbol)));
                                             }
-                                        } else {
-                                            logger.fine("====> collected: Ignoring token: " + symbol);
                                         }
                                     }
                                 }
                             } else {
                                 if (set.contains(currentSymbol)) {
-                                    if (showDebugOutput && logger.isLoggable(Level.FINE)) {
-                                        logger.fine("=====> consumed: " + this.vocabulary.getDisplayName(currentSymbol));
+                                    if (showDebugOutput) {
+                                        System.out.println("=====> consumed: " +
+                                                vocabulary.getDisplayName(currentSymbol));
                                     }
-                                    statePipeline.addLast(new PipelineEntry(transition.target, currentEntry.tokenIndex + 1));
+                                    statePipeline.push(new PipelineEntry(transition.target,
+                                            currentEntry.tokenListIndex + 1));
                                 }
                             }
                         }
@@ -598,93 +490,143 @@ public class CodeCompletionCore {
             }
         }
 
-        callStack.removeLast();
+        callStack.remove(callStack.size() - 1);
+        if (startState.isLeftRecursiveRule) {
+            precedenceStack.remove(precedenceStack.size() - 1);
+        }
 
-        // Cache the result, for later lookup to avoid duplicate walks.
-        positionMap.put(tokenIndex, result);
+        positionMap.put(tokenListIndex, result);
+        return result;
+    }
+
+    private String generateBaseDescription(ATNState state) {
+        String stateValue = state.stateNumber == ATNState.INVALID_STATE_NUMBER ? "Invalid"
+                : String.valueOf(state.stateNumber);
+        String typeName = atnStateTypeMap[state.getStateType()];
+
+        return "[" + stateValue + " " + typeName + "] in " + ruleNames[state.ruleIndex];
+    }
+
+    private void printDescription(int indentation, ATNState state, String baseDescription, int tokenIndex) {
+        String indent = String.join("", Collections.nCopies(indentation, "  "));
+        StringBuilder output = new StringBuilder(indent);
+
+        StringBuilder transitionDescription = new StringBuilder();
+        if (debugOutputWithTransitions) {
+            for (Transition transition : state.getTransitions()) {
+                StringBuilder labels = new StringBuilder();
+                IntervalSet label = transition.label();
+                List<Integer> symbols = label != null ? label.toList() : Collections.emptyList();
+
+                if (symbols.size() > 2) {
+                    labels.append(vocabulary.getDisplayName(symbols.get(0)))
+                            .append(" .. ")
+                            .append(vocabulary.getDisplayName(symbols.get(symbols.size() - 1)));
+                } else {
+                    for (int symbol : symbols) {
+                        if (labels.length() > 0) {
+                            labels.append(", ");
+                        }
+                        labels.append(vocabulary.getDisplayName(symbol));
+                    }
+                }
+
+                if (labels.length() == 0) {
+                    labels.append("ε");
+                }
+
+                String typeName = atnStateTypeMap[transition.target.getStateType()];
+                transitionDescription.append("\n").append(indent).append("\t(").append(labels)
+                        .append(") [").append(transition.target.stateNumber).append(" ")
+                        .append(typeName).append("] in ").append(ruleNames[transition.target.ruleIndex]);
+            }
+        }
+
+        if (tokenIndex >= tokens.size() - 1) {
+            output.append("<<").append(tokenStartIndex + tokenIndex).append(">> ");
+        } else {
+            output.append("<").append(tokenStartIndex + tokenIndex).append("> ");
+        }
+        System.out.println(output.toString() + "Current state: " + baseDescription + transitionDescription);
+    }
+
+    private void printRuleState(List<RuleWithStartToken> stack) {
+        if (stack.isEmpty()) {
+            System.out.println("<empty stack>");
+            return;
+        }
+
+        for (RuleWithStartToken rule : stack) {
+            System.out.println(ruleNames[rule.ruleIndex]);
+        }
+    }
+
+    private static List<Integer> longestCommonPrefix(List<Integer> a, List<Integer> b) {
+        int minLength = Math.min(a.size(), b.size());
+        List<Integer> result = new ArrayList<>();
+
+        for (int i = 0; i < minLength; i++) {
+            if (a.get(i).equals(b.get(i))) {
+                result.add(a.get(i));
+            } else {
+                break;
+            }
+        }
 
         return result;
     }
 
-    private String[] atnStateTypeMap = new String[] {
-        "invalid",
-        "basic",
-        "rule start",
-        "block start",
-        "plus block start",
-        "star block start",
-        "token start",
-        "rule stop",
-        "block end",
-        "star loop back",
-        "star loop entry",
-        "plus loop back",
-        "loop end"
-    };
-
-    private String generateBaseDescription(ATNState state) {
-        String stateValue = (state.stateNumber == ATNState.INVALID_STATE_NUMBER) ? "Invalid" : Integer.toString(state.stateNumber);
-        return "[" + stateValue + " " + this.atnStateTypeMap[state.getStateType()] + "] in " + this.ruleNames[state.ruleIndex];
+    // Supporting classes
+    public static class CandidatesCollection {
+        public Map<Integer, List<Integer>> tokens = new HashMap<>();
+        public Map<Integer, CandidateRule> rules = new HashMap<>();
     }
 
-    private void printDescription(String currentIndent, ATNState state, String baseDescription, int tokenIndex) {
+    public static class CandidateRule {
+        public int startTokenIndex;
+        public List<Integer> ruleList;
 
-        StringBuilder output = new StringBuilder(currentIndent);
-
-        StringBuilder transitionDescription = new StringBuilder();
-        if (this.debugOutputWithTransitions && logger.isLoggable(Level.FINER)) {
-            for (Transition transition: state.getTransitions()) {
-                StringBuilder labels = new StringBuilder();
-                List<Integer> symbols = (transition.label() != null) ? transition.label().toList() : new LinkedList<>();
-                if (symbols.size() > 2) {
-                    // Only print start and end symbols to avoid large lists in debug output.
-                    labels.append(this.vocabulary.getDisplayName(symbols.get(0)) + " .. " + this.vocabulary.getDisplayName(symbols.get(symbols.size() - 1)));
-                } else {
-                    for (Integer symbol: symbols) {
-                        if (labels.length() > 0) {
-                            labels.append(", ");
-                        }
-                        labels.append(this.vocabulary.getDisplayName(symbol));
-                    }
-                }
-                if (labels.length() == 0) {
-                    labels.append("ε");
-                }
-                transitionDescription.
-                        append("\n").
-                        append(currentIndent).
-                        append("\t(").
-                        append(labels).
-                        append(") [").
-                        append(transition.target.stateNumber).
-                        append(" ").
-                        append(this.atnStateTypeMap[transition.target.getStateType()]).
-                        append("] in ").
-                        append(this.ruleNames[transition.target.ruleIndex]);
-            }
-
-            if (tokenIndex >= this.tokens.size() - 1) {
-                output.append("<<").append(this.tokenStartIndex + tokenIndex).append(">> ");
-            } else {
-                output.append("<").append(this.tokenStartIndex + tokenIndex).append("> ");
-            }
-            logger.finer(output + "Current state: " + baseDescription + transitionDescription);
+        public CandidateRule(int startTokenIndex, List<Integer> ruleList) {
+            this.startTokenIndex = startTokenIndex;
+            this.ruleList = ruleList;
         }
     }
 
-    private void printRuleState(LinkedList<Integer> stack) {
-        if (stack.isEmpty()) {
-            logger.fine("<empty stack>");
-            return;
-        }
+    public static class RuleWithStartToken {
+        public int startTokenIndex;
+        public int ruleIndex;
 
-        if (logger.isLoggable(Level.FINER)) {
-            StringBuilder sb = new StringBuilder();
-            for (Integer rule : stack) {
-                sb.append("  ").append(this.ruleNames[rule]).append("\n");
-            }
-            logger.log(Level.FINER, sb.toString());
+        public RuleWithStartToken(int startTokenIndex, int ruleIndex) {
+            this.startTokenIndex = startTokenIndex;
+            this.ruleIndex = ruleIndex;
         }
     }
 
+    private static class FollowSetWithPath {
+        public IntervalSet intervals;
+        public List<Integer> path = new ArrayList<>();
+        public List<Integer> following = new ArrayList<>();
+    }
+
+    private static class FollowSetsHolder {
+        public List<FollowSetWithPath> sets;
+        public IntervalSet combined;
+        public boolean isExhaustive;
+
+        public FollowSetsHolder(List<FollowSetWithPath> sets, IntervalSet combined, boolean isExhaustive) {
+            this.sets = sets;
+            this.combined = combined;
+            this.isExhaustive = isExhaustive;
+        }
+    }
+
+    private static class PipelineEntry {
+        public ATNState state;
+        public int tokenListIndex;
+
+        public PipelineEntry(ATNState state, int tokenListIndex) {
+            this.state = state;
+            this.tokenListIndex = tokenListIndex;
+        }
+    }
 }

--- a/ports/java/src/test/antlr4/com/vmware/antlr4c3/Whitebox.g4
+++ b/ports/java/src/test/antlr4/com/vmware/antlr4c3/Whitebox.g4
@@ -1,0 +1,47 @@
+grammar Whitebox;
+
+@eader {
+/* eslint-disable @typescript-eslint/no-unused-vars, no-useless-escape */
+}
+
+test1: rule1 ADIPISCING ;
+rule1: rule2 CONSECTETUR ;
+rule2: LOREM rule3 rule5 SIT* AMET? ;
+rule3: rule4 DOLOR? ;
+rule4: IPSUM? ;
+rule5: ;
+
+test2: rule7 ADIPISCING ;
+rule7: rule8 CONSECTETUR ;
+rule8: LOREM rule11 rule9 SIT* AMET? ;
+rule9: rule10 DOLOR? ;
+rule10: IPSUM? ;
+rule11: ;
+
+test3: LOREM IPSUM? rule13 AMET+ CONSECTETUR ;
+rule13: (DOLOR | SIT)* ;
+
+test4: LOREM (rule15 | rule16) ;
+rule15: IPSUM DOLOR SIT ;
+rule16: IPSUM DOLOR AMET ;
+
+test5: LOREM (rule15 | rule16) ;
+rule18: IPSUM DOLOR (SIT | CONSECTETUR) ;
+rule19: IPSUM DOLOR AMET ;
+
+test6: LOREM (rule15 | rule16) ;
+rule21: IPSUM DOLOR SIT ;
+rule22: IPSUM DOLOR (AMET | CONSECTETUR) ;
+
+test7: LOREM (IPSUM DOLOR SIT | IPSUM DOLOR AMET) ;
+
+test8: LOREM (IPSUM DOLOR SIT AMET | IPSUM DOLOR SIT CONSECTETUR) ;
+
+LOREM: 'LOREM';
+IPSUM: 'IPSUM';
+DOLOR: 'DOLOR';
+SIT: 'SIT';
+AMET: 'AMET';
+CONSECTETUR: 'CONSECTETUR';
+ADIPISCING: 'ADIPISCING';
+WS: [ \n\r\t] -> skip;

--- a/ports/java/src/test/java/com/vmware/antlr4c3/CountingErrorListener.java
+++ b/ports/java/src/test/java/com/vmware/antlr4c3/CountingErrorListener.java
@@ -1,0 +1,16 @@
+package com.vmware.antlr4c3;
+
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+
+public class CountingErrorListener extends BaseErrorListener {
+    public int errorCount = 0;
+
+    @Override
+    public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine,
+            String msg, RecognitionException e) {
+        super.syntaxError(recognizer, offendingSymbol, line, charPositionInLine, msg, e);
+        errorCount++;
+    }
+}

--- a/ports/java/src/test/java/com/vmware/antlr4c3/ExprTest.java
+++ b/ports/java/src/test/java/com/vmware/antlr4c3/ExprTest.java
@@ -12,43 +12,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Logger;
-
-import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.RecognitionException;
-import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-/**
- * Unit tests for CodeCompletionCore
- */
-public class TestCodeCompletionCore {
-
-    private static final Logger logger = Logger.getLogger(TestCodeCompletionCore.class.getName());
-
-    public static class CountingErrorListener extends BaseErrorListener {
-
-        public int errorCount = 0;
-
-        @Override
-        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
-            super.syntaxError(recognizer, offendingSymbol, line, charPositionInLine, msg, e);
-            errorCount++;
-
-        }
-    }
-
+public class ExprTest {
     @Test
-    public void test1_simpleExpressionTest() throws Exception {
-
-        System.out.println();
-        System.out.println("simpleExpressionTest");
-
+    public void simpleExpressionTest() throws Exception {
         String expression = "var c = a + b()";
         ExprLexer lexer = new ExprLexer(CharStreams.fromString(expression));
         CommonTokenStream tokens = new CommonTokenStream(lexer);
@@ -76,14 +49,15 @@ public class TestCodeCompletionCore {
         assertTrue(candidates.tokens.containsKey(ExprLexer.ID));
 
         { // TS: expected [ExprLexer.ID, ExprLexer.EQUAL], here got []
-            assertEquals(Arrays.asList(new Integer[]{}), candidates.tokens.get(ExprLexer.VAR));
-            assertEquals(Arrays.asList(new Integer[]{}), candidates.tokens.get(ExprLexer.LET));
+            assertEquals(Arrays.asList(new Integer[] {}), candidates.tokens.get(ExprLexer.VAR));
+            assertEquals(Arrays.asList(new Integer[] {}), candidates.tokens.get(ExprLexer.LET));
         }
 
-        assertEquals(Arrays.asList(new Integer[]{}), candidates.tokens.get(ExprLexer.ID));
+        assertEquals(Arrays.asList(new Integer[] {}), candidates.tokens.get(ExprLexer.ID));
 
-        // 2) On the first whitespace. In real implementations you would do some additional checks where in the whitespace
-        //    the caret is, as the outcome is different depending on that position.
+        // 2) On the first whitespace. In real implementations you would do some
+        // additional checks where in the whitespace
+        // the caret is, as the outcome is different depending on that position.
         candidates = core.collectCandidates(1, null);
         assertEquals(1, candidates.tokens.size());
         assertTrue(candidates.tokens.containsKey(ExprLexer.ID));
@@ -98,14 +72,16 @@ public class TestCodeCompletionCore {
         assertEquals(1, candidates.tokens.size());
         assertTrue(candidates.tokens.containsKey(ExprLexer.EQUAL));
 
-        // 5) On the variable reference 'a'. But since we have not configure the c3 engine to return us var refs
-        //    (or function refs for that matter) we only get an ID here.
+        // 5) On the variable reference 'a'. But since we have not configure the c3
+        // engine to return us var refs
+        // (or function refs for that matter) we only get an ID here.
         candidates = core.collectCandidates(6, null);
         assertEquals(1, candidates.tokens.size());
         assertTrue(candidates.tokens.containsKey(ExprLexer.ID));
 
-        // 6) On the '+' operator. Usually you would not show operators as candidates, but we have not set up the c3 engine
-        //    yet to not return them.
+        // 6) On the '+' operator. Usually you would not show operators as candidates,
+        // but we have not set up the c3 engine
+        // yet to not return them.
         candidates = core.collectCandidates(8, null);
         assertEquals(5, candidates.tokens.size());
         assertTrue(candidates.tokens.containsKey(ExprLexer.PLUS));
@@ -116,11 +92,7 @@ public class TestCodeCompletionCore {
     }
 
     @Test
-    public void test2_typicalExpressionTest() throws Exception {
-
-        System.out.println();
-        System.out.println("typicalExpressionTest");
-
+    public void typicalExpressionTest() throws Exception {
         String expression = "var c = a + b";
         ExprLexer lexer = new ExprLexer(CharStreams.fromString(expression));
         CommonTokenStream tokens = new CommonTokenStream(lexer);
@@ -137,8 +109,10 @@ public class TestCodeCompletionCore {
 
         assertEquals(0, errorListener.errorCount);
 
-        // Tell the engine to return certain rules to us, which we could use to look up values in a symbol table.
-        Set<Integer> preferredRules = new HashSet<>(Arrays.asList(ExprParser.RULE_functionRef, ExprParser.RULE_variableRef));
+        // Tell the engine to return certain rules to us, which we could use to look up
+        // values in a symbol table.
+        Set<Integer> preferredRules = new HashSet<>(
+                Arrays.asList(ExprParser.RULE_functionRef, ExprParser.RULE_variableRef));
 
         // Ignore operators and the generic ID token.
         Set<Integer> ignoredTokens = new HashSet<>(Arrays.asList(ExprLexer.ID,
@@ -153,8 +127,8 @@ public class TestCodeCompletionCore {
         assertTrue(candidates.tokens.containsKey(ExprLexer.VAR));
         assertTrue(candidates.tokens.containsKey(ExprLexer.LET));
 
-        assertEquals(Arrays.asList(new Integer[]{}), candidates.tokens.get(ExprLexer.VAR));
-        assertEquals(Arrays.asList(new Integer[]{}), candidates.tokens.get(ExprLexer.LET));
+        assertEquals(Arrays.asList(new Integer[] {}), candidates.tokens.get(ExprLexer.VAR));
+        assertEquals(Arrays.asList(new Integer[] {}), candidates.tokens.get(ExprLexer.LET));
 
         // 2) On the variable name ('c').
         candidates = core.collectCandidates(2, null);
@@ -169,7 +143,8 @@ public class TestCodeCompletionCore {
         assertEquals(0, candidates.tokens.size());
         assertEquals(2, candidates.rules.size());
 
-        // Here we get 2 rule indexes, derived from 2 different IDs possible at this caret position.
+        // Here we get 2 rule indexes, derived from 2 different IDs possible at this
+        // caret position.
         // These are what we told the engine above to be preferred rules for us.
         int found = 0;
         for (Map.Entry<Integer, List<Integer>> candidate : candidates.rules.entrySet()) {

--- a/ports/java/src/test/java/com/vmware/antlr4c3/ExprTest.java
+++ b/ports/java/src/test/java/com/vmware/antlr4c3/ExprTest.java
@@ -9,18 +9,22 @@ package com.vmware.antlr4c3;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.atn.PredictionMode;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import static org.junit.jupiter.api.Assertions.*;
 
-import static org.junit.Assert.*;
-
+@TestMethodOrder(OrderAnnotation.class)
 public class ExprTest {
     @Test
-    public void simpleExpressionTest() throws Exception {
+    @Order(1)
+    public void mostSimpleSetup() throws Exception {
+        System.out.println(1);
         String expression = "var c = a + b()";
         ExprLexer lexer = new ExprLexer(CharStreams.fromString(expression));
         CommonTokenStream tokens = new CommonTokenStream(lexer);
@@ -32,7 +36,7 @@ public class ExprTest {
         parser.addErrorListener(errorListener);
 
         // Specify our entry point
-        ExprParser.ExpressionContext tree = parser.expression();
+        parser.expression();
 
         assertEquals(0, errorListener.errorCount);
 
@@ -47,12 +51,9 @@ public class ExprTest {
         assertTrue(candidates.tokens.containsKey(ExprLexer.LET));
         assertTrue(candidates.tokens.containsKey(ExprLexer.ID));
 
-        { // TS: expected [ExprLexer.ID, ExprLexer.EQUAL], here got []
-            assertEquals(Arrays.asList(new Integer[] {}), candidates.tokens.get(ExprLexer.VAR));
-            assertEquals(Arrays.asList(new Integer[] {}), candidates.tokens.get(ExprLexer.LET));
-        }
-
-        assertEquals(Arrays.asList(new Integer[] {}), candidates.tokens.get(ExprLexer.ID));
+        assertEquals(List.of(ExprLexer.ID, ExprLexer.EQUAL), candidates.tokens.get(ExprLexer.VAR));
+        assertEquals(List.of(ExprLexer.ID, ExprLexer.EQUAL), candidates.tokens.get(ExprLexer.LET));
+        assertEquals(List.of(), candidates.tokens.get(ExprLexer.ID));
 
         // 2) On the first whitespace. In real implementations you would do some
         // additional checks where in the whitespace
@@ -91,7 +92,9 @@ public class ExprTest {
     }
 
     @Test
+    @Order(2)
     public void typicalExpressionTest() throws Exception {
+        System.out.println(2);
         String expression = "var c = a + b";
         ExprLexer lexer = new ExprLexer(CharStreams.fromString(expression));
         CommonTokenStream tokens = new CommonTokenStream(lexer);
@@ -128,8 +131,8 @@ public class ExprTest {
         assertTrue(candidates.tokens.containsKey(ExprLexer.VAR));
         assertTrue(candidates.tokens.containsKey(ExprLexer.LET));
 
-        assertEquals(Arrays.asList(new Integer[] {}), candidates.tokens.get(ExprLexer.VAR));
-        assertEquals(Arrays.asList(new Integer[] {}), candidates.tokens.get(ExprLexer.LET));
+        assertEquals(List.of(ExprLexer.ID, ExprLexer.EQUAL), candidates.tokens.get(ExprLexer.VAR));
+        assertEquals(List.of(ExprLexer.ID, ExprLexer.EQUAL), candidates.tokens.get(ExprLexer.LET));
 
         // 2) On the variable name ('c').
         candidates = core.collectCandidates(2, null);

--- a/ports/java/src/test/java/com/vmware/antlr4c3/ExprTest.java
+++ b/ports/java/src/test/java/com/vmware/antlr4c3/ExprTest.java
@@ -9,7 +9,6 @@ package com.vmware.antlr4c3;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.antlr.v4.runtime.CharStreams;
@@ -37,7 +36,7 @@ public class ExprTest {
 
         assertEquals(0, errorListener.errorCount);
 
-        CodeCompletionCore core = new CodeCompletionCore(parser, null, null);
+        CodeCompletionCore core = new CodeCompletionCore(parser);
 
         // 1) At the input start.
 
@@ -118,7 +117,9 @@ public class ExprTest {
         Set<Integer> ignoredTokens = new HashSet<>(Arrays.asList(ExprLexer.ID,
                 ExprLexer.PLUS, ExprLexer.MINUS, ExprLexer.MULTIPLY, ExprLexer.DIVIDE, ExprLexer.EQUAL));
 
-        CodeCompletionCore core = new CodeCompletionCore(parser, preferredRules, ignoredTokens);
+        CodeCompletionCore core = new CodeCompletionCore(parser);
+        core.preferredRules = preferredRules;
+        core.ignoredTokens = ignoredTokens;
 
         // 1) At the input start.
         CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(0, null);
@@ -147,7 +148,7 @@ public class ExprTest {
         // caret position.
         // These are what we told the engine above to be preferred rules for us.
         int found = 0;
-        for (Map.Entry<Integer, List<Integer>> candidate : candidates.rules.entrySet()) {
+        for (Map.Entry<Integer, CodeCompletionCore.CandidateRule> candidate : candidates.rules.entrySet()) {
             switch (candidate.getKey()) {
                 case ExprParser.RULE_functionRef: {
                     found++;
@@ -172,7 +173,7 @@ public class ExprTest {
 
         // Here we get 2 rule indexes
         found = 0;
-        for (Map.Entry<Integer, List<Integer>> candidate : candidates.rules.entrySet()) {
+        for (Map.Entry<Integer, CodeCompletionCore.CandidateRule> candidate : candidates.rules.entrySet()) {
             switch (candidate.getKey()) {
                 case ExprParser.RULE_functionRef: {
                     found++;

--- a/ports/java/src/test/java/com/vmware/antlr4c3/WhiteboxTest.java
+++ b/ports/java/src/test/java/com/vmware/antlr4c3/WhiteboxTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2017 VMware, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * See LICENSE file for more info.
+ */
 package com.vmware.antlr4c3;
 
 import static org.junit.Assert.assertEquals;
@@ -29,7 +36,7 @@ public class WhiteboxTest {
 
         assertEquals(1, errorListener.errorCount);
 
-        CodeCompletionCore core = new CodeCompletionCore(parser, null, null);
+        CodeCompletionCore core = new CodeCompletionCore(parser);
         CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(1, ctx);
 
         assertEquals(5, candidates.tokens.size());
@@ -54,7 +61,7 @@ public class WhiteboxTest {
         ParserRuleContext ctx = parser.test2();
         assertEquals(1, errorListener.errorCount);
 
-        CodeCompletionCore core = new CodeCompletionCore(parser, null, null);
+        CodeCompletionCore core = new CodeCompletionCore(parser);
         CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(1, ctx);
 
         assertEquals(5, candidates.tokens.size());
@@ -79,7 +86,7 @@ public class WhiteboxTest {
         ParserRuleContext ctx = parser.test3();
         assertEquals(1, errorListener.errorCount);
 
-        CodeCompletionCore core = new CodeCompletionCore(parser, null, null);
+        CodeCompletionCore core = new CodeCompletionCore(parser);
         CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(1, ctx);
 
         assertEquals(4, candidates.tokens.size());
@@ -115,7 +122,7 @@ public class WhiteboxTest {
                     throw new IllegalStateException();
             }
 
-            CodeCompletionCore core = new CodeCompletionCore(parser, null, null);
+            CodeCompletionCore core = new CodeCompletionCore(parser);
             CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(2, ctx);
 
             assertEquals(Set.of(WhiteboxLexer.DOLOR), candidates.tokens.keySet());
@@ -132,7 +139,7 @@ public class WhiteboxTest {
         WhiteboxParser parser = new WhiteboxParser(tokenStream);
         ParserRuleContext ctx = parser.test8();
 
-        CodeCompletionCore core = new CodeCompletionCore(parser, null, null);
+        CodeCompletionCore core = new CodeCompletionCore(parser);
         CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(2, ctx);
 
         assertEquals(1, candidates.tokens.size());

--- a/ports/java/src/test/java/com/vmware/antlr4c3/WhiteboxTest.java
+++ b/ports/java/src/test/java/com/vmware/antlr4c3/WhiteboxTest.java
@@ -7,9 +7,6 @@
  */
 package com.vmware.antlr4c3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
 import java.util.Set;
 
@@ -17,7 +14,8 @@ import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WhiteboxTest {
     @Test

--- a/ports/java/src/test/java/com/vmware/antlr4c3/WhiteboxTest.java
+++ b/ports/java/src/test/java/com/vmware/antlr4c3/WhiteboxTest.java
@@ -1,0 +1,142 @@
+package com.vmware.antlr4c3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.junit.Test;
+
+public class WhiteboxTest {
+    @Test
+    public void caretAtTransitionToRuleWithNonExhaustiveFollowSetTest() {
+        CharStream inputStream = CharStreams.fromString("LOREM ");
+
+        WhiteboxLexer lexer = new WhiteboxLexer(inputStream);
+        CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+
+        WhiteboxParser parser = new WhiteboxParser(tokenStream);
+        CountingErrorListener errorListener = new CountingErrorListener();
+        parser.removeErrorListeners();
+        parser.addErrorListener(errorListener);
+
+        ParserRuleContext ctx = parser.test1();
+
+        assertEquals(1, errorListener.errorCount);
+
+        CodeCompletionCore core = new CodeCompletionCore(parser, null, null);
+        CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(1, ctx);
+
+        assertEquals(5, candidates.tokens.size());
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.IPSUM));
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.DOLOR));
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.SIT));
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.AMET));
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.CONSECTETUR));
+    }
+
+    @Test
+    public void caretAtTransitionToRuleWithEmptyFollowSetTest() {
+        CharStream inputStream = CharStreams.fromString("LOREM ");
+        WhiteboxLexer lexer = new WhiteboxLexer(inputStream);
+        CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+
+        WhiteboxParser parser = new WhiteboxParser(tokenStream);
+        CountingErrorListener errorListener = new CountingErrorListener();
+        parser.removeErrorListeners();
+        parser.addErrorListener(errorListener);
+
+        ParserRuleContext ctx = parser.test2();
+        assertEquals(1, errorListener.errorCount);
+
+        CodeCompletionCore core = new CodeCompletionCore(parser, null, null);
+        CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(1, ctx);
+
+        assertEquals(5, candidates.tokens.size());
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.IPSUM));
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.DOLOR));
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.SIT));
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.AMET));
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.CONSECTETUR));
+    }
+
+    @Test
+    public void caretAtOptionalTokenTest() {
+        CharStream inputStream = CharStreams.fromString("LOREM ");
+        WhiteboxLexer lexer = new WhiteboxLexer(inputStream);
+        CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+
+        WhiteboxParser parser = new WhiteboxParser(tokenStream);
+        CountingErrorListener errorListener = new CountingErrorListener();
+        parser.removeErrorListeners();
+        parser.addErrorListener(errorListener);
+
+        ParserRuleContext ctx = parser.test3();
+        assertEquals(1, errorListener.errorCount);
+
+        CodeCompletionCore core = new CodeCompletionCore(parser, null, null);
+        CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(1, ctx);
+
+        assertEquals(4, candidates.tokens.size());
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.IPSUM));
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.DOLOR));
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.SIT));
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.AMET));
+    }
+
+    @Test
+    public void caretAtOneOfMultiplePossibleStatesTest() {
+        for (int index : new int[] { 4, 5, 6, 7 }) {
+            CharStream inputStream = CharStreams.fromString("LOREM IPSUM ");
+            WhiteboxLexer lexer = new WhiteboxLexer(inputStream);
+            CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+
+            WhiteboxParser parser = new WhiteboxParser(tokenStream);
+            ParserRuleContext ctx;
+            switch (index) {
+                case 4:
+                    ctx = parser.test4();
+                    break;
+                case 5:
+                    ctx = parser.test5();
+                    break;
+                case 6:
+                    ctx = parser.test6();
+                    break;
+                case 7:
+                    ctx = parser.test7();
+                    break;
+                default:
+                    throw new IllegalStateException();
+            }
+
+            CodeCompletionCore core = new CodeCompletionCore(parser, null, null);
+            CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(2, ctx);
+
+            assertEquals(Set.of(WhiteboxLexer.DOLOR), candidates.tokens.keySet());
+            assertTrue(candidates.tokens.get(WhiteboxLexer.DOLOR).isEmpty());
+        }
+    }
+
+    @Test
+    public void caretAtOneOfMultiplePossibleStatesWithCommonFollowListTest() {
+        CharStream inputStream = CharStreams.fromString("LOREM IPSUM ");
+        WhiteboxLexer lexer = new WhiteboxLexer(inputStream);
+        CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+
+        WhiteboxParser parser = new WhiteboxParser(tokenStream);
+        ParserRuleContext ctx = parser.test8();
+
+        CodeCompletionCore core = new CodeCompletionCore(parser, null, null);
+        CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(2, ctx);
+
+        assertEquals(1, candidates.tokens.size());
+        assertTrue(candidates.tokens.containsKey(WhiteboxLexer.DOLOR));
+        assertEquals(List.of(WhiteboxLexer.SIT), candidates.tokens.get(WhiteboxLexer.DOLOR));
+    }
+}


### PR DESCRIPTION
- [x] Added VSCode Devcontaner configuration
- [x] Translated `Whitebox` tests from `TypeScript` to `Java` using an LLM.
- [x] Translated `Expr` tests from `TypeScript` to `Java` using an LLM.
- [x] Translated `CodeCompletionCore` from `TypeScript` to `Java` using an LLM.
- [ ] Fix a bug with a `ignoredToken` dependency at `followSet` computation