### PR TITLE
#138 Use Conan to manage C++ port dependencies

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Configure
         working-directory: ${{github.workspace}}/ports/cpp
         run: |
+          conan profile detect
+
           conan install . \
             --output-folder=build \
             --build=missing \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         cmake_build_type: [Asan, Release]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,6 +31,7 @@ jobs:
           sudo apt update
           sudo apt install build-essential
           sudo apt install clang-format-18 clang-tidy-18
+          pip install conan
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -45,7 +46,11 @@ jobs:
       - name: Configure
         working-directory: ${{github.workspace}}/ports/cpp
         run: |
-          mkdir build
+          conan install . \
+            --output-folder=build \
+            --build=missing \
+            --settings=build_type=${{ matrix.cmake_build_type }}
+
           cd build
           cmake \
             -DANTLR4C3_DEVELOPER=ON \

--- a/ports/cpp/.gitignore
+++ b/ports/cpp/.gitignore
@@ -2,5 +2,8 @@
 build/
 build-asan/
 
+# Conan
+CMakeUserPresets.json
+
 # Clangd
 .cache

--- a/ports/cpp/README.md
+++ b/ports/cpp/README.md
@@ -39,19 +39,19 @@ Actual build steps are available at [CMake GitHub Workflow](../../.github/workfl
 git clone git@github.com:mike-lischke/antlr4-c3.git
 cd antlr4-c3/ports/cpp # Also a workspace directory for VSCode
 
-# Create and enter the build directory
-mkdir build && cd build
+# Setup the Conan project
+# - build_type Asan and Tsan are supported too
+conan install . --output-folder=build --build=missing --settings=build_type=Debug
 
 # Configure CMake build
 # - ANTLR4C3_DEVELOPER should be enabled if you are going to run tests
-# - CMAKE_BUILD_TYPE Asan and Tsan are supported too
-cmake -DANTLR4C3_DEVELOPER=ON -DCMAKE_BUILD_TYPE=Release ..
+(cd build && cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Debug -DANTLR4C3_DEVELOPER=ON)
 
 # Build everything
-make
+(cd build && make)
 
 # Running tests being at build directory
-(make && cd test && ctest)
+(cd build && make && cd test && ctest)
 ```
 
 ## Contributing

--- a/ports/cpp/README.md
+++ b/ports/cpp/README.md
@@ -18,7 +18,7 @@ Please see the parent [README.md](../../readme.md) for an explanation of the lib
 
 - [ANTLRv4 C++ Runtime](https://github.com/antlr/antlr4/tree/4.13.1/runtime/Cpp) to compile sources.
 
-- [CMake 3.7](https://cmake.org/cmake/help/latest/release/3.7.html) to build project.
+- [CMake 3.7](https://cmake.org/cmake/help/latest/release/3.7.html) and [Conan](https://conan.io/) to build project.
 
 - [ANTLRv4 Tool](https://www.antlr.org/download.html) to build tests.
 

--- a/ports/cpp/README.md
+++ b/ports/cpp/README.md
@@ -41,6 +41,7 @@ cd antlr4-c3/ports/cpp # Also a workspace directory for VSCode
 
 # Setup the Conan project
 # - build_type Asan and Tsan are supported too
+conan profile detect
 conan install . --output-folder=build --build=missing --settings=build_type=Debug
 
 # Configure CMake build

--- a/ports/cpp/ci/test.sh
+++ b/ports/cpp/ci/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 cd "$(dirname "$0")"/../build/test
 
 ctest

--- a/ports/cpp/cmake/FindAntlr4Cpp.cmake
+++ b/ports/cpp/cmake/FindAntlr4Cpp.cmake
@@ -1,6 +1,4 @@
-set(ANTLR4_WITH_STATIC_CRT OFF)
-set(ANTLR4_ZIP_REPOSITORY https://github.com/antlr/antlr4/archive/refs/tags/${ANTLR4_TAG}.zip)
-add_definitions(-DANTLR4CPP_STATIC)
-include(ExternalAntlr4Cpp)
+find_package(antlr4-runtime REQUIRED)
+include_directories(${antlr4-cppruntime_INCLUDES})
 
 set(ANTLR4C3_ANTLR4_STATIC antlr4_static)

--- a/ports/cpp/cmake/FindAntlr4Tool.cmake
+++ b/ports/cpp/cmake/FindAntlr4Tool.cmake
@@ -1,15 +1,24 @@
-file(
-    DOWNLOAD 
-    https://www.antlr.org/download/antlr-${ANTLR4_TAG}-complete.jar 
-    ${CMAKE_BINARY_DIR}/antlr-${ANTLR4_TAG}-complete.jar
-)
-set(ANTLR_EXECUTABLE ${CMAKE_BINARY_DIR}/antlr-${ANTLR4_TAG}-complete.jar)
+find_package(antlr4 REQUIRED)
+
+if(DEFINED antlr4_PACKAGE_FOLDER_DEBUG)
+  set(ANTLR4C3_ANTLR4_TOOL_PATH ${antlr4_PACKAGE_FOLDER_DEBUG})
+else()
+  set(ANTLR4C3_ANTLR4_TOOL_PATH ${antlr4_PACKAGE_FOLDER_RELEASE})
+endif()
+
+if(DEFINED openjdk_BIN_DIRS_DEBUG)
+  set(ANTLR4C3_JAVA_PATH ${openjdk_BIN_DIRS_DEBUG})
+else()
+  set(ANTLR4C3_JAVA_PATH ${openjdk_BIN_DIRS_RELEASE})
+endif()
+
+set(ANTLR_COMPLETE ${ANTLR4C3_ANTLR4_TOOL_PATH}/res/antlr-complete.jar)
 
 function(antlr_generate grammar directory)
     message(STATUS "antlr_generate ${grammar} ${directory}")
     execute_process(
-        COMMAND bash -c "java \
-            -jar ${ANTLR_EXECUTABLE} \
+        COMMAND bash -c "${ANTLR4C3_JAVA_PATH}/java \
+            -classpath ${ANTLR_COMPLETE} org.antlr.v4.Tool \
             -o ${directory} \
             -listener -visitor -Dlanguage=Cpp \
             ${grammar} \

--- a/ports/cpp/conanfile.py
+++ b/ports/cpp/conanfile.py
@@ -1,0 +1,13 @@
+from conan import ConanFile
+
+
+class ANTLR4C3Conan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    requires = (
+        "antlr4/4.13.1",
+        "antlr4-cppruntime/4.13.1",
+    )
+    generators = {
+        "CMakeDeps",
+        "CMakeToolchain",
+    }


### PR DESCRIPTION
This is a step forward to publish `antlr4-c3` C++ port to Conan package registry. It is not yet publishable, but now uses Conan to get the `ANTLR4 C++ Runtime` and the `ANTLR4 Tool.`